### PR TITLE
Performance Fixes Round One

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For example:
     "logDirectory": "/usr/local/lib/metrics-aggregator-daemon/logs",
     "pipelinesDirectory": "/usr/local/lib/metrics-aggregator-daemon/config/pipelines",
     "httpHost": "0.0.0.0",
-    "httpPort": 6080,
+    "httpPort": 7090,
     "httpHealthCheckPath": "/mad/healthcheck",
     "httpStatusPath": "/mad/status",
     "jvmMetricsCollectionInterval": "PT.5S",

--- a/maven/maven-wrapper.properties
+++ b/maven/maven-wrapper.properties
@@ -1,3 +1,2 @@
-#Maven download properties
-#Thu Mar 24 10:19:40 PDT 2016
+#Wed Mar 23 23:30:00 UTC 2016
 distributionUrl=https\://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.9/apache-maven-3.3.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,13 @@
     <akka.http.version>2.4.2</akka.http.version>
     <apache.httpclient.version>4.5.1</apache.httpclient.version>
     <apache.httpcore.version>4.4.3</apache.httpcore.version>
-    <arpnetworking.commons.version>1.3.0</arpnetworking.commons.version>
-    <cglib.version>3.1</cglib.version>
+    <arpnetworking.commons.version>1.4.0</arpnetworking.commons.version>
+    <aspectjrt.version>1.8.8</aspectjrt.version>
+    <cglib.version>3.2.1</cglib.version>
     <commons.codec.version>1.10</commons.codec.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.math3.version>3.3</commons.math3.version>
-    <findbugs.annotations.version>3.0.0</findbugs.annotations.version>
+    <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
     <guava.version>18.0</guava.version>
     <guice.version>4.0</guice.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
@@ -94,11 +95,11 @@
     <log4j.over.slf4j.version>1.7.12</log4j.over.slf4j.version>
     <metrics.aggregator.protocol.version>1.0.2</metrics.aggregator.protocol.version>
     <metrics.client.version>0.4.5</metrics.client.version>
-    <metrics.generator.version>1.0.3</metrics.generator.version>
+    <metrics.generator.version>1.1.0</metrics.generator.version>
     <metrics.jvm.extra.version>0.4.2</metrics.jvm.extra.version>
     <mockito.version>1.10.19</mockito.version>
     <oval.version>1.82</oval.version>
-    <performance.test.version>1.0.0</performance.test.version>
+    <performance.test.version>1.1.0</performance.test.version>
     <protobuf.version>2.6.1</protobuf.version>
     <reflections.version>0.9.10</reflections.version>
     <scala.version>2.11</scala.version>
@@ -109,6 +110,10 @@
     <typesafe.config.version>1.2.1</typesafe.config.version>
     <vertx.core.version>2.1.6</vertx.core.version>
     <wiremock.version>1.57</wiremock.version>
+
+    <!-- Additional Plugins -->
+    <aspectjtools.maven.plugin>1.8.8</aspectjtools.maven.plugin>
+    <aspectj.maven.plugin.version>1.8</aspectj.maven.plugin.version>
 
     <!-- Findbugs -->
     <findbugs.exclude>${project.basedir}/findbugs.exclude.xml</findbugs.exclude>
@@ -189,6 +194,38 @@
             </program>
           </programs>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>aspectj-maven-plugin</artifactId>
+        <version>${aspectj.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <complianceLevel>1.8</complianceLevel>
+          <aspectLibraries>
+            <aspectLibrary>
+              <groupId>com.arpnetworking.logback</groupId>
+              <artifactId>logback-steno</artifactId>
+            </aspectLibrary>
+          </aspectLibraries>
+          <showWeaveInfo>true</showWeaveInfo>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjtools</artifactId>
+            <version>${aspectjtools.maven.plugin}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>
@@ -287,6 +324,11 @@
       <version>${jackson.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-afterburner</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
     <!-- Akka -->
     <dependency>
       <groupId>com.typesafe.akka</groupId>
@@ -331,7 +373,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
+      <artifactId>findbugs-annotations</artifactId>
       <version>${findbugs.annotations.version}</version>
     </dependency>
     <dependency>
@@ -373,6 +415,12 @@
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
       <version>${reflections.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjrt</artifactId>
+      <version>${aspectjrt.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>cglib</groupId>
@@ -478,7 +526,7 @@
                   <parallel combine.self="override" />
                   <forkCount>1</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>-agentlib:hprof=cpu=samples,depth=15,interval=5,force=n,file=${basedir}/target/perf.profile.hprof.txt</argLine>
+                  <argLine>-agentlib:hprof=cpu=samples,depth=15,interval=5,force=y,file=${basedir}/target/perf.profile.hprof.txt</argLine>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/java/com/arpnetworking/configuration/jackson/BaseJacksonConfiguration.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/BaseJacksonConfiguration.java
@@ -29,6 +29,7 @@ import net.sf.oval.constraint.NotNull;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.function.Function;
 
 /**
  * Common base class for <code>Configuration</code> implementations based on
@@ -184,12 +185,13 @@ public abstract class BaseJacksonConfiguration extends com.arpnetworking.configu
     protected abstract static class Builder<T extends Builder<?, ?>, S extends Configuration> extends OvalBuilder<S> {
 
         /**
-         * Protected constructor.
+         * Protected constructor for subclasses.
          *
-         * @param clazz The target <code>Class</code> to build.
+         * @param targetConstructor The constructor for the concrete type to be created by this builder.
          */
-        protected Builder(final Class<S> clazz) {
-            super(clazz);
+        @SuppressWarnings(value = {"rawtypes", "unchecked"})
+        protected Builder(final Function<T, S> targetConstructor) {
+            super((Function<? extends Builder, S>) targetConstructor);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/BaseJsonNodeSource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/BaseJsonNodeSource.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import net.sf.oval.constraint.NotNull;
 
+import java.util.function.Function;
+
 /**
  * Abstract base class for <code>JsonSource</code> implementations.
  *
@@ -90,12 +92,13 @@ public abstract class BaseJsonNodeSource implements JsonNodeSource {
     protected abstract static class Builder<T extends Builder<?, ?>, S extends JsonNodeSource> extends OvalBuilder<S> {
 
         /**
-         * Protected constructor.
+         * Protected constructor for subclasses.
          *
-         * @param clazz The target <code>Class</code> to build.
+         * @param targetConstructor The constructor for the concrete type to be created by this builder.
          */
-        protected Builder(final Class<S> clazz) {
-            super(clazz);
+        @SuppressWarnings(value = {"rawtypes", "unchecked"})
+        protected Builder(final Function<T, S> targetConstructor) {
+            super((Function<? extends Builder, S>) targetConstructor);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/DirectoryDynamicConfigurationFactory.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/DirectoryDynamicConfigurationFactory.java
@@ -117,7 +117,7 @@ public final class DirectoryDynamicConfigurationFactory implements DynamicConfig
          * Public constructor.
          */
         public Builder() {
-            super(DirectoryDynamicConfigurationFactory.class);
+            super(DirectoryDynamicConfigurationFactory::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/DynamicConfiguration.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/DynamicConfiguration.java
@@ -282,7 +282,7 @@ public final class DynamicConfiguration extends BaseJacksonConfiguration impleme
          * Public constructor.
          */
         public Builder() {
-            super(DynamicConfiguration.class);
+            super(DynamicConfiguration::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeDirectorySource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeDirectorySource.java
@@ -124,7 +124,7 @@ public final class JsonNodeDirectorySource extends BaseJsonNodeSource {
          * Public constructor.
          */
         public Builder() {
-            super(JsonNodeDirectorySource.class);
+            super(JsonNodeDirectorySource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeFileSource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeFileSource.java
@@ -98,7 +98,7 @@ public final class JsonNodeFileSource extends BaseJsonNodeSource {
          * Public constructor.
          */
         public Builder() {
-            super(JsonNodeFileSource.class);
+            super(JsonNodeFileSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeLiteralSource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeLiteralSource.java
@@ -81,7 +81,7 @@ public final class JsonNodeLiteralSource extends BaseJsonNodeSource {
          * Public constructor.
          */
         public Builder() {
-            super(JsonNodeLiteralSource.class);
+            super(JsonNodeLiteralSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeMergingSource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeMergingSource.java
@@ -134,7 +134,7 @@ public final class JsonNodeMergingSource implements JsonNodeSource {
          * Public constructor.
          */
         public Builder() {
-            super(JsonNodeMergingSource.class);
+            super(JsonNodeMergingSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/JsonNodePaginatedUriSource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/JsonNodePaginatedUriSource.java
@@ -125,7 +125,7 @@ public final class JsonNodePaginatedUriSource extends BaseJsonNodeSource {
          * Public constructor.
          */
         public Builder() {
-            super(JsonNodePaginatedUriSource.class);
+            super(JsonNodePaginatedUriSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeUriSource.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/JsonNodeUriSource.java
@@ -122,7 +122,7 @@ public final class JsonNodeUriSource extends BaseJsonNodeSource {
          * Public constructor.
          */
         public Builder() {
-            super(JsonNodeUriSource.class);
+            super(JsonNodeUriSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/MergingDynamicConfigurationFactory.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/MergingDynamicConfigurationFactory.java
@@ -90,7 +90,7 @@ public final class MergingDynamicConfigurationFactory implements DynamicConfigur
          * Public constructor.
          */
         public Builder() {
-            super(MergingDynamicConfigurationFactory.class);
+            super(MergingDynamicConfigurationFactory::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/jackson/StaticConfiguration.java
+++ b/src/main/java/com/arpnetworking/configuration/jackson/StaticConfiguration.java
@@ -67,7 +67,7 @@ public final class StaticConfiguration extends BaseJacksonConfiguration {
          * Public constructor.
          */
         public Builder() {
-            super(StaticConfiguration.class);
+            super(StaticConfiguration::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/triggers/DirectoryTrigger.java
+++ b/src/main/java/com/arpnetworking/configuration/triggers/DirectoryTrigger.java
@@ -184,7 +184,7 @@ public final class DirectoryTrigger implements Trigger {
          * Public constructor.
          */
         public Builder() {
-            super(DirectoryTrigger.class);
+            super(DirectoryTrigger::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/triggers/FileTrigger.java
+++ b/src/main/java/com/arpnetworking/configuration/triggers/FileTrigger.java
@@ -156,7 +156,7 @@ public final class FileTrigger implements Trigger {
          * Public constructor.
          */
         public Builder() {
-            super(FileTrigger.class);
+            super(FileTrigger::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/configuration/triggers/UriTrigger.java
+++ b/src/main/java/com/arpnetworking/configuration/triggers/UriTrigger.java
@@ -215,7 +215,7 @@ public final class UriTrigger implements Trigger {
          * Public constructor.
          */
         public Builder() {
-            super(UriTrigger.class);
+            super(UriTrigger::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/common/sources/BaseSource.java
+++ b/src/main/java/com/arpnetworking/metrics/common/sources/BaseSource.java
@@ -23,6 +23,8 @@ import com.arpnetworking.steno.LogValueMapFactory;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
 
+import java.util.function.Function;
+
 /**
  * Abstract base class for common functionality for reading
  * <code>AggregatedData</code>. This class is thread safe.
@@ -126,11 +128,10 @@ public abstract class BaseSource implements Source {
         /**
          * Protected constructor for subclasses.
          *
-         * @param targetClass The concrete type to be created by the builder of
-         * <code>Source</code> implementation.
+         * @param targetConstructor The constructor for the concrete type to be created by this builder.
          */
-        protected Builder(final Class<? extends Source> targetClass) {
-            super(targetClass);
+        protected Builder(final Function<B, Source> targetConstructor) {
+            super(targetConstructor);
         }
 
         @NotNull

--- a/src/main/java/com/arpnetworking/metrics/common/sources/FileSource.java
+++ b/src/main/java/com/arpnetworking/metrics/common/sources/FileSource.java
@@ -244,7 +244,7 @@ public final class FileSource<T> extends BaseSource {
          * Public constructor.
          */
         public Builder() {
-            super(FileSource.class);
+            super(FileSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/common/tailer/FilePositionStore.java
+++ b/src/main/java/com/arpnetworking/metrics/common/tailer/FilePositionStore.java
@@ -229,7 +229,7 @@ public final class FilePositionStore implements PositionStore {
         private static final class Builder extends OvalBuilder<Descriptor> {
 
             private Builder() {
-                super(Descriptor.class);
+                super(Descriptor::new);
             }
 
             public Builder setPosition(final Long value) {
@@ -260,7 +260,7 @@ public final class FilePositionStore implements PositionStore {
          * Public constructor.
          */
         public Builder() {
-            super(FilePositionStore.class);
+            super(FilePositionStore::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/common/tailer/StatefulTailer.java
+++ b/src/main/java/com/arpnetworking/metrics/common/tailer/StatefulTailer.java
@@ -528,7 +528,7 @@ public final class StatefulTailer implements Tailer {
 
     // NOTE: Package private for testing
 
-    /* package private */StatefulTailer(final Builder builder, final Trigger trigger) {
+    /* package private */ StatefulTailer(final Builder builder, final Trigger trigger) {
         _file = builder._file;
         _positionStore = builder._positionStore;
         _listener = builder._listener;
@@ -618,7 +618,7 @@ public final class StatefulTailer implements Tailer {
          * Public constructor.
          */
         public Builder() {
-            super(StatefulTailer.class);
+            super((java.util.function.Function<Builder, StatefulTailer>) StatefulTailer::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/Aggregator.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/Aggregator.java
@@ -324,7 +324,7 @@ public final class Aggregator implements Observer, Launchable {
          * Public constructor.
          */
         public Builder() {
-            super(Aggregator.class);
+            super(Aggregator::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/Bucket.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/Bucket.java
@@ -426,10 +426,8 @@ import java.util.function.BiFunction;
         /**
          * Public constructor.
          */
-        // CHECKSTYLE.OFF: RedundantModifierCheck - This is probably a checkstyle bug.
-        public Builder() {
-            // CHECKSTYLE.ON: RedundantModifierCheck
-            super(Bucket.class);
+        /* package private */ Builder() {
+            super(Bucket::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/PeriodWorker.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/PeriodWorker.java
@@ -281,7 +281,7 @@ import java.util.concurrent.LinkedBlockingDeque;
          * Public constructor.
          */
         Builder() {
-            super(PeriodWorker.class);
+            super(PeriodWorker::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/configuration/AggregatorConfiguration.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/configuration/AggregatorConfiguration.java
@@ -17,8 +17,6 @@ package com.arpnetworking.metrics.mad.configuration;
 
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.Loggable;
-import com.arpnetworking.utility.InterfaceDatabase;
-import com.arpnetworking.utility.ReflectionsDatabase;
 import com.google.common.base.MoreObjects;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
@@ -114,8 +112,6 @@ public final class AggregatorConfiguration {
     private final Period _jvmMetricsCollectionInterval;
     private final Map<String, ?> _akkaConfiguration;
 
-    private static final InterfaceDatabase INTERFACE_DATABASE = ReflectionsDatabase.newInstance();
-
     /**
      * Implementation of builder pattern for <code>TsdAggregatorConfiguration</code>.
      *
@@ -127,7 +123,7 @@ public final class AggregatorConfiguration {
          * Public constructor.
          */
         public Builder() {
-            super(AggregatorConfiguration.class);
+            super(AggregatorConfiguration::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/configuration/PipelineConfiguration.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/configuration/PipelineConfiguration.java
@@ -23,8 +23,6 @@ import com.arpnetworking.tsdcore.sinks.Sink;
 import com.arpnetworking.tsdcore.statistics.Statistic;
 import com.arpnetworking.tsdcore.statistics.StatisticDeserializer;
 import com.arpnetworking.tsdcore.statistics.StatisticFactory;
-import com.arpnetworking.utility.InterfaceDatabase;
-import com.arpnetworking.utility.ReflectionsDatabase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -148,7 +146,6 @@ public final class PipelineConfiguration {
     private final ImmutableSet<Statistic> _gaugeStatistic;
     private final ImmutableMap<String, Set<Statistic>> _statistics;
 
-    private static final InterfaceDatabase INTERFACE_DATABASE = ReflectionsDatabase.newInstance();
     private static final StatisticFactory STATISTIC_FACTORY = new StatisticFactory();
 
     /**
@@ -162,7 +159,7 @@ public final class PipelineConfiguration {
          * Public constructor.
          */
         public Builder() {
-            super(PipelineConfiguration.class);
+            super(PipelineConfiguration::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/DefaultMetric.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/DefaultMetric.java
@@ -126,7 +126,7 @@ public final class DefaultMetric implements Metric {
          * Public constructor.
          */
         public Builder() {
-            super(DefaultMetric.class);
+            super(DefaultMetric::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/DefaultRecord.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/DefaultRecord.java
@@ -167,7 +167,7 @@ public final class DefaultRecord implements Record {
          * Public constructor.
          */
         public Builder() {
-            super(DefaultRecord.class);
+            super(DefaultRecord::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2c.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2c.java
@@ -80,7 +80,7 @@ public final class Version2c {
          * Public constructor.
          */
         public Builder() {
-            super(Version2c.class);
+            super(Version2c::new);
         }
 
         /**
@@ -186,7 +186,7 @@ public final class Version2c {
              * Public constructor.
              */
             public Builder() {
-                super(Annotations.class);
+                super(Annotations::new);
             }
 
             /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2d.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2d.java
@@ -83,7 +83,7 @@ public final class Version2d {
          * Public constructor.
          */
         public Builder() {
-            super(Version2d.class);
+            super(Version2d::new);
         }
 
         /**
@@ -183,7 +183,7 @@ public final class Version2d {
              * Public constructor.
              */
             public Builder() {
-                super(Sample.class);
+                super(Sample::new);
             }
 
             /**
@@ -239,7 +239,7 @@ public final class Version2d {
              * Public constructor.
              */
             public Builder() {
-                super(Element.class);
+                super(Element::new);
             }
 
             /**
@@ -293,7 +293,7 @@ public final class Version2d {
              * Public constructor.
              */
             public Builder() {
-                super(Annotations.class);
+                super(Annotations::new);
             }
 
             /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2e.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2e.java
@@ -98,7 +98,7 @@ public final class Version2e {
          * Public constructor.
          */
         public Builder() {
-            super(Version2e.class);
+            super(Version2e::new);
         }
 
         /**
@@ -229,7 +229,7 @@ public final class Version2e {
              * Public constructor.
              */
             public Builder() {
-                super(Data.class);
+                super(Data::new);
             }
 
             /**
@@ -327,7 +327,7 @@ public final class Version2e {
              * Public constructor.
              */
             public Builder() {
-                super(Sample.class);
+                super(Sample::new);
             }
 
             /**
@@ -383,7 +383,7 @@ public final class Version2e {
              * Public constructor.
              */
             public Builder() {
-                super(Element.class);
+                super(Element::new);
             }
 
             /**
@@ -437,7 +437,7 @@ public final class Version2e {
              * Public constructor.
              */
             public Builder() {
-                super(Annotations.class);
+                super(Annotations::new);
             }
 
             /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2f.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2f.java
@@ -88,7 +88,7 @@ public final class Version2f {
          * Public constructor.
          */
         public Builder() {
-            super(Version2f.class);
+            super(Version2f::new);
         }
 
         /**
@@ -192,7 +192,7 @@ public final class Version2f {
              * Public constructor.
              */
             public Builder() {
-                super(Sample.class);
+                super(Sample::new);
             }
 
             /**
@@ -259,7 +259,7 @@ public final class Version2f {
              * Public constructor.
              */
             public Builder() {
-                super(Element.class);
+                super(Element::new);
             }
 
             /**
@@ -336,7 +336,7 @@ public final class Version2f {
              * Public constructor.
              */
             public Builder() {
-                super(Annotations.class);
+                super(Annotations::new);
             }
 
             /**

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2fSteno.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2fSteno.java
@@ -95,7 +95,7 @@ public final class Version2fSteno {
          * Public constructor.
          */
         public Builder() {
-            super(Version2fSteno.class);
+            super(Version2fSteno::new);
         }
 
         /**
@@ -209,7 +209,7 @@ public final class Version2fSteno {
              * Public constructor.
              */
             public Builder() {
-                super(Context.class);
+                super(Context::new);
             }
 
             /**
@@ -292,7 +292,7 @@ public final class Version2fSteno {
              * Public constructor.
              */
             public Builder() {
-                super(Data.class);
+                super(Data::new);
             }
 
             /**
@@ -397,7 +397,7 @@ public final class Version2fSteno {
              * Public constructor.
              */
             public Builder() {
-                super(Sample.class);
+                super(Sample::new);
             }
 
             /**
@@ -464,7 +464,7 @@ public final class Version2fSteno {
              * Public constructor.
              */
             public Builder() {
-                super(Element.class);
+                super(Element::new);
             }
 
             /**
@@ -529,7 +529,7 @@ public final class Version2fSteno {
              * Public constructor.
              */
             public Builder() {
-                super(Annotations.class);
+                super(Annotations::new);
             }
 
             /**

--- a/src/main/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParser.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParser.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -406,7 +407,7 @@ public final class JsonToRecordParser implements Parser<Record> {
     private static final String DATA_KEY = "data";
     private static final String VERSION_KEY = "version";
     private static final String LOCAL_HOST_NAME;
-    private static final Logger INVALID_SAMPLE_LOGGER = LoggerFactory.getRateLimitLogger(JsonToRecordParser.class, Duration.ofMinutes(1));
+    private static final Logger INVALID_SAMPLE_LOGGER = LoggerFactory.getRateLimitLogger(JsonToRecordParser.class, Duration.ofSeconds(30));
 
     private static final Function<String, Quantity> VERSION_2C_SAMPLE_TO_QUANTITY = sample -> {
         if (sample != null) {
@@ -530,6 +531,7 @@ public final class JsonToRecordParser implements Parser<Record> {
                         EnumerationDeserializerStrategyUsingToUpperCase.<Unit>newInstance()));
         OBJECT_MAPPER.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
         OBJECT_MAPPER.registerModule(queryLogParserModule);
+        OBJECT_MAPPER.registerModule(new AfterburnerModule());
 
         final String localHostName;
         try {
@@ -550,7 +552,7 @@ public final class JsonToRecordParser implements Parser<Record> {
          * Public constructor.
          */
         public Builder() {
-            super(JsonToRecordParser.class);
+            super(JsonToRecordParser::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/metrics/mad/sources/MappingSource.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/sources/MappingSource.java
@@ -237,7 +237,7 @@ public final class MappingSource extends BaseSource {
          * Public constructor.
          */
         public Builder() {
-            super(MappingSource.class);
+            super(MappingSource::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/AggregatedData.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/AggregatedData.java
@@ -244,7 +244,7 @@ public final class AggregatedData implements Serializable {
          * Public constructor.
          */
         public Builder() {
-            super(AggregatedData.class);
+            super(AggregatedData::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/CalculatedValue.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/CalculatedValue.java
@@ -52,9 +52,8 @@ public final class CalculatedValue<T> {
         /**
          * Public constructor.
          */
-        @SuppressWarnings("unchecked")
         public Builder() {
-            super((Class<CalculatedValue<T>>) (Class<?>) CalculatedValue.class);
+            super((java.util.function.Function<Builder<T>, CalculatedValue<T>>) CalculatedValue::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/Condition.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/Condition.java
@@ -89,7 +89,7 @@ public final class Condition {
          * Public constructor.
          */
         public Builder() {
-            super(Condition.class);
+            super(Condition::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/FQDSN.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/FQDSN.java
@@ -130,7 +130,7 @@ public final class FQDSN implements Serializable {
          * Public constructor.
          */
         public Builder() {
-            super(FQDSN.class);
+            super(FQDSN::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/FQSN.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/FQSN.java
@@ -152,7 +152,7 @@ public final class FQSN {
          * Public constructor.
          */
         public Builder() {
-            super(FQSN.class);
+            super(FQSN::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/PeriodicData.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/PeriodicData.java
@@ -159,7 +159,7 @@ public final class PeriodicData {
          * Public constructor.
          */
         public Builder() {
-            super(PeriodicData.class);
+            super(PeriodicData::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/model/Quantity.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/Quantity.java
@@ -322,7 +322,7 @@ public final class Quantity implements Comparable<Quantity>, Serializable {
          * Public constructor.
          */
         public Builder() {
-            super(Quantity.class);
+            super((java.util.function.Function<Builder, Quantity>) Quantity::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/AggregationServerSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/AggregationServerSink.java
@@ -21,12 +21,10 @@ import com.arpnetworking.steno.LoggerFactory;
 import com.arpnetworking.tsdcore.model.AggregatedData;
 import com.arpnetworking.tsdcore.model.AggregationMessage;
 import com.arpnetworking.tsdcore.model.PeriodicData;
-import com.arpnetworking.tsdcore.model.Quantity;
 import com.arpnetworking.tsdcore.statistics.HistogramStatistic;
 import com.arpnetworking.tsdcore.statistics.Statistic;
 import com.arpnetworking.tsdcore.statistics.StatisticFactory;
 import com.google.protobuf.ByteString;
-import net.sf.oval.constraint.NotNull;
 import org.joda.time.DateTime;
 import org.vertx.java.core.Handler;
 import org.vertx.java.core.net.NetSocket;
@@ -93,7 +91,7 @@ public final class AggregationServerSink extends VertxSink {
                 .setPeriodStart(periodicData.getStart().toString())
                 .setCluster(firstElement.getFQDSN().getCluster())
                 .setService(firstElement.getFQDSN().getService())
-                .setForwardHostData(_forwardHostData);
+                .setForwardHostData(true);
 
         for (final AggregatedData datum : periodicData.getData()) {
             if (EXPRESSION_STATISTIC.equals(datum.getFQDSN().getStatistic())) {
@@ -166,7 +164,6 @@ public final class AggregationServerSink extends VertxSink {
 
     private AggregationServerSink(final Builder builder) {
         super(builder);
-        _forwardHostData = builder._forwardHostData;
         super.getVertx().setPeriodic(15000, new Handler<Long>() {
             @Override
             public void handle(final Long event) {
@@ -179,12 +176,7 @@ public final class AggregationServerSink extends VertxSink {
         });
     }
 
-    private final boolean _forwardHostData;
-
     private boolean _sentHandshake = false;
-
-    private static final com.google.common.base.Function<Quantity, Double> EXTRACT_VALUES_FROM_SAMPLES =
-            input -> input != null ? input.getValue() : null;
 
     private static final StatisticFactory STATISTIC_FACTORY = new StatisticFactory();
     private static final Statistic EXPRESSION_STATISTIC = STATISTIC_FACTORY.getStatistic("expression");
@@ -201,20 +193,8 @@ public final class AggregationServerSink extends VertxSink {
          * Public constructor.
          */
         public Builder() {
-            super(AggregationServerSink.class);
+            super(AggregationServerSink::new);
             setServerPort(7065);
-        }
-
-        /**
-         * Whether or not the aggregation server should forward this host data to its sinks.
-         * Optional. Default is false.
-         *
-         * @param value Forward the data; true = forward and aggregate, false = just aggregate.
-         * @return This instance of <code>Builder</code>.
-         */
-        public Builder setForwardHostData(final Boolean value) {
-            _forwardHostData = value;
-            return self();
         }
 
         /**
@@ -224,8 +204,5 @@ public final class AggregationServerSink extends VertxSink {
         protected Builder self() {
             return this;
         }
-
-        @NotNull
-        private Boolean _forwardHostData = false;
     }
 }

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/BaseSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/BaseSink.java
@@ -18,11 +18,10 @@ package com.arpnetworking.tsdcore.sinks;
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.logback.annotations.LogValue;
 import com.arpnetworking.steno.LogValueMapFactory;
-import com.arpnetworking.tsdcore.statistics.Statistic;
-import com.arpnetworking.tsdcore.statistics.StatisticFactory;
-import com.google.common.collect.ImmutableSet;
 import net.sf.oval.constraint.NotEmpty;
 import net.sf.oval.constraint.NotNull;
+
+import java.util.function.Function;
 
 /**
  * Abstract base class for common functionality for publishing
@@ -71,9 +70,6 @@ public abstract class BaseSink implements Sink {
 
     private final String _name;
 
-    private static final StatisticFactory STATISTIC_FACTORY = new StatisticFactory();
-    private static final ImmutableSet<Statistic> ALL_STATISTICS = STATISTIC_FACTORY.getAllStatistics();
-
     /**
      * Base <code>Builder</code> implementation.
      *
@@ -106,11 +102,10 @@ public abstract class BaseSink implements Sink {
         /**
          * Protected constructor for subclasses.
          *
-         * @param targetClass The concrete type to be created by the builder of
-         * <code>Sink</code> implementation.
+         * @param targetConstructor The constructor for the concrete type to be created by this builder.
          */
-        protected Builder(final Class<? extends S> targetClass) {
-            super(targetClass);
+        protected Builder(final Function<B, S> targetConstructor) {
+            super(targetConstructor);
         }
 
         @NotNull

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/MultiSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/MultiSink.java
@@ -100,7 +100,7 @@ public final class MultiSink extends BaseSink {
          * Public constructor.
          */
         public Builder() {
-            super(MultiSink.class);
+            super(MultiSink::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/PeriodFilteringSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/PeriodFilteringSink.java
@@ -123,7 +123,7 @@ public final class PeriodFilteringSink extends BaseSink {
          * Public constructor.
          */
         public Builder() {
-            super(PeriodFilteringSink.class);
+            super(PeriodFilteringSink::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSink.java
@@ -240,7 +240,7 @@ public final class PeriodicStatisticsSink extends BaseSink {
          * Public constructor.
          */
         public Builder() {
-            super(PeriodicStatisticsSink.class);
+            super(PeriodicStatisticsSink::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/TelemetrySink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/TelemetrySink.java
@@ -91,7 +91,7 @@ public final class TelemetrySink extends BaseSink {
          * Public constructor.
          */
         public Builder() {
-            super(TelemetrySink.class);
+            super(TelemetrySink::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/TimeThresholdSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/TimeThresholdSink.java
@@ -164,7 +164,7 @@ public final class TimeThresholdSink extends BaseSink {
          * Public constructor.
          */
         public Builder() {
-            super(TimeThresholdSink.class);
+            super(TimeThresholdSink::new);
         }
 
         /**

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/VertxSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/VertxSink.java
@@ -40,6 +40,7 @@ import org.vertx.java.core.net.NetSocket;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 /**
  * Abstract publisher to send data to a server via Vertx <code>NetSocket</code>.
@@ -482,11 +483,10 @@ public abstract class VertxSink extends BaseSink {
         /**
          * Protected constructor for subclasses.
          *
-         * @param targetClass The concrete type to be created by the builder of
-         * <code>AggregatedDataSink</code> implementation.
+         * @param targetConstructor The constructor for the concrete type to be created by this builder.
          */
-        protected Builder(final Class<S> targetClass) {
-            super(targetClass);
+        protected Builder(final Function<B, S> targetConstructor) {
+            super(targetConstructor);
         }
 
         @NotNull

--- a/src/main/java/com/arpnetworking/tsdcore/statistics/HistogramStatistic.java
+++ b/src/main/java/com/arpnetworking/tsdcore/statistics/HistogramStatistic.java
@@ -233,7 +233,7 @@ public final class HistogramStatistic extends BaseStatistic {
              * Public constructor.
              */
             public Builder() {
-                super(HistogramSupportingData.class);
+                super(HistogramSupportingData::new);
             }
 
             /**

--- a/src/test/java/com/arpnetworking/metrics/common/sources/BaseSourceTest.java
+++ b/src/test/java/com/arpnetworking/metrics/common/sources/BaseSourceTest.java
@@ -138,7 +138,7 @@ public class BaseSourceTest {
             }
 
             private Builder() {
-                super(TestSource.class);
+                super(TestSource::new);
             }
         }
     }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2cTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2cTest.java
@@ -39,7 +39,7 @@ import java.util.Map;
  *
  * @author Brandon Arp (barp at groupon dot com)
  */
-public class QueryLogParserV2cTest {
+public class JsonToRecordParserV2cTest {
 
     @Test
     public void testParse() throws ParsingException, IOException {
@@ -303,7 +303,7 @@ public class QueryLogParserV2cTest {
                 .setDefaultService("MyService")
                 .build()
                 .parse(Resources.toByteArray(
-                        Resources.getResource(QueryLogParserV2cTest.class, "QueryLogParserV2cTest/testDefaultHostname.json")));
+                        Resources.getResource(JsonToRecordParserV2cTest.class, "QueryLogParserV2cTest/testDefaultHostname.json")));
         Assert.assertFalse(Strings.isNullOrEmpty(record.getHost()));
 
     }
@@ -315,6 +315,6 @@ public class QueryLogParserV2cTest {
                 .setDefaultHost("MyHost")
                 .build()
                 .parse(Resources.toByteArray(
-                        Resources.getResource(QueryLogParserV2cTest.class, fileName)));
+                        Resources.getResource(JsonToRecordParserV2cTest.class, fileName)));
     }
 }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2dTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2dTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
  *
  * @author Brandon Arp (barp at groupon dot com)
  */
-public class QueryLogParserV2dTest {
+public class JsonToRecordParserV2dTest {
 
     @Test
     public void testParse() throws ParsingException, IOException {
@@ -178,6 +178,6 @@ public class QueryLogParserV2dTest {
                 .setDefaultService("MyService")
                 .setDefaultHost("MyHost")
                 .build()
-                .parse(Resources.toByteArray(Resources.getResource(QueryLogParserV2dTest.class, fileName)));
+                .parse(Resources.toByteArray(Resources.getResource(JsonToRecordParserV2dTest.class, fileName)));
     }
 }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2eTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2eTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
  *
  * @author Ville Koskela (vkoskela at groupon dot com)
  */
-public class QueryLogParserV2eTest {
+public class JsonToRecordParserV2eTest {
 
     @Test
     public void testParse() throws ParsingException, IOException {
@@ -378,6 +378,6 @@ public class QueryLogParserV2eTest {
                 .setDefaultService("MyService")
                 .setDefaultHost("MyHost")
                 .build()
-                .parse(Resources.toByteArray(Resources.getResource(QueryLogParserV2eTest.class, fileName)));
+                .parse(Resources.toByteArray(Resources.getResource(JsonToRecordParserV2eTest.class, fileName)));
     }
 }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fStenoTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fStenoTest.java
@@ -35,18 +35,18 @@ import java.util.Map;
  *
  * @author Ville Koskela (vkoskela at groupon dot com)
  */
-public class QueryLogParserV2fTest {
+public class JsonToRecordParserV2fStenoTest {
 
     @Test
     public void testParse() throws ParsingException, IOException {
         // TODO(vkoskela): Test compound units [MAI-679]
 
-        final Record record = parseRecord("QueryLogParserV2fTest/testParse.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testParse.json");
         Assert.assertNotNull(record);
         Assert.assertEquals("MyCluster", record.getCluster());
         Assert.assertEquals("MyService", record.getService());
         Assert.assertEquals("MyHost", record.getHost());
-        Assert.assertEquals("6be33313-bb39-423a-a928-1d0cc0da60a9", record.getId());
+        Assert.assertEquals("oRw59PrARvatGNC7fiWw4A", record.getId());
         Assert.assertFalse(record.getId().isEmpty());
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -82,7 +82,7 @@ public class QueryLogParserV2fTest {
 
     @Test
     public void testEmpty() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testEmpty.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testEmpty.json");
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -91,87 +91,102 @@ public class QueryLogParserV2fTest {
     }
 
     @Test(expected = ParsingException.class)
+    public void testContainerMissingContext() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingContext.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerNullContext() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullContext.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerMissingHost() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingHost.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerNullHost() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullHost.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerEmptyHost() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerEmptyHost.json");
+    }
+
+    @Test(expected = ParsingException.class)
     public void testMissingAnnotationService() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingAnnotationService.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testMissingAnnotationId() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingAnnotationId.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testMissingAnnotationHost() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingAnnotationHost.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingAnnotationService.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingAnnotationCluster() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingAnnotationCluster.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingAnnotationCluster.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testEmptyAnnotationService() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationService.json");
+        parseRecord("QueryLogParserV2fStenoTest/testEmptyAnnotationService.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testEmptyAnnotationCluster() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationCluster.json");
+        parseRecord("QueryLogParserV2fStenoTest/testEmptyAnnotationCluster.json");
     }
 
     @Test(expected = ParsingException.class)
-    public void testEmptyAnnotationId() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationId.json");
+    public void testContainerNullId() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullId.json");
     }
 
     @Test(expected = ParsingException.class)
-    public void testEmptyAnnotationHost() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationHost.json");
+    public void testContainerMissingId() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingId.json");
     }
 
     @Test
     public void testNullCounters() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testNullCounters.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNullCounters.json");
         Assert.assertNotNull(record);
     }
 
     @Test
     public void testNullTimers() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testNullTimers.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNullTimers.json");
         Assert.assertNotNull(record);
     }
 
     @Test
     public void testNullGauges() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testNullGauges.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNullGauges.json");
         Assert.assertNotNull(record);
     }
 
     @Test
     public void testMissingCounters() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testMissingCounters.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testMissingCounters.json");
         Assert.assertNotNull(record);
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
     @Test
     public void testMissingTimers() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testMissingTimers.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testMissingTimers.json");
         Assert.assertNotNull(record);
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
     @Test
     public void testMissingGauges() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testMissingGauges.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testMissingGauges.json");
         Assert.assertNotNull(record);
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
     @Test
     public void testEmptyValues() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testEmptyValues.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testEmptyValues.json");
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -195,163 +210,233 @@ public class QueryLogParserV2fTest {
 
     @Test
     public void testUpperCaseVersion() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testUpperCaseVersion.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testUpperCaseVersion.json");
         Assert.assertNotNull(record);
     }
 
     @Test(expected = ParsingException.class)
+    public void testContainerMissingData() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingData.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerMissingLevel() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingLevel.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerMissingName() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingName.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerMissingTime() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingTime.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerNullData() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullData.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerNullLevel() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullLevel.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerNullName() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullName.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerNullTime() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerNullTime.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerBadData() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerBadData.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerBadLevel() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerBadLevel.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerBadName() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerBadName.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerBadTime() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerBadTime.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerBadContext() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerBadContext.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testContainerContextBadHost() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fStenoTest/testContainerContextBadHost.json");
+    }
+
+    @Test(expected = ParsingException.class)
     public void testBadCounters() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounters.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounters.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimers() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimers.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimers.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGauges() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGauges.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGauges.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingGaugeValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingGaugeValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingGaugeValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingTimerValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingTimerValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingTimerValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingCounterValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingCounterValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingCounterValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testNullGaugeValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testNullGaugeValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testNullGaugeValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testNullTimerValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testNullTimerValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testNullTimerValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testNullCounterValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testNullCounterValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testNullCounterValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGaugeValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimerValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounterValues.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingCounterValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingCounterValuesValue.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingCounterValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingGaugeValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingGaugeValuesValue.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingGaugeValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingTimerValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testMissingTimerValuesValue.json");
+        parseRecord("QueryLogParserV2fStenoTest/testMissingTimerValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValue.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValue.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValue.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueNumeratorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueNumeratorUnits.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueNumeratorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueDenominatorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueDenominatorUnits.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueDenominatorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueNumeratorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueNumeratorUnits.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueNumeratorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueDenominatorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueDenominatorUnits.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueDenominatorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueNumeratorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueNumeratorUnits.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueNumeratorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueDenominatorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueDenominatorUnits.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueDenominatorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueNumeratorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueNumeratorUnitsName.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueNumeratorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueDenominatorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueDenominatorUnitsName.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueDenominatorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueNumeratorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueNumeratorUnitsName.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueNumeratorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueDenominatorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueDenominatorUnitsName.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueDenominatorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueNumeratorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueNumeratorUnitsName.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueNumeratorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueDenominatorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueDenominatorUnitsName.json");
+        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueDenominatorUnitsName.json");
     }
 
     @Test
     public void testNaNValues() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fTest/testNaNValues.json");
+        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNaNValues.json");
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -395,6 +480,6 @@ public class QueryLogParserV2fTest {
         return new JsonToRecordParser.Builder()
                 .build()
                 .parse(Resources.toByteArray(Resources.getResource(
-                        QueryLogParserV2fTest.class, fileName)));
+                        JsonToRecordParserV2fStenoTest.class, fileName)));
     }
 }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fTest.java
@@ -35,18 +35,18 @@ import java.util.Map;
  *
  * @author Ville Koskela (vkoskela at groupon dot com)
  */
-public class QueryLogParserV2fStenoTest {
+public class JsonToRecordParserV2fTest {
 
     @Test
     public void testParse() throws ParsingException, IOException {
         // TODO(vkoskela): Test compound units [MAI-679]
 
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testParse.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testParse.json");
         Assert.assertNotNull(record);
         Assert.assertEquals("MyCluster", record.getCluster());
         Assert.assertEquals("MyService", record.getService());
         Assert.assertEquals("MyHost", record.getHost());
-        Assert.assertEquals("oRw59PrARvatGNC7fiWw4A", record.getId());
+        Assert.assertEquals("6be33313-bb39-423a-a928-1d0cc0da60a9", record.getId());
         Assert.assertFalse(record.getId().isEmpty());
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -82,7 +82,7 @@ public class QueryLogParserV2fStenoTest {
 
     @Test
     public void testEmpty() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testEmpty.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testEmpty.json");
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -91,102 +91,87 @@ public class QueryLogParserV2fStenoTest {
     }
 
     @Test(expected = ParsingException.class)
-    public void testContainerMissingContext() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingContext.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerNullContext() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullContext.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerMissingHost() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingHost.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerNullHost() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullHost.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerEmptyHost() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerEmptyHost.json");
-    }
-
-    @Test(expected = ParsingException.class)
     public void testMissingAnnotationService() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingAnnotationService.json");
+        parseRecord("QueryLogParserV2fTest/testMissingAnnotationService.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testMissingAnnotationId() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fTest/testMissingAnnotationId.json");
+    }
+
+    @Test(expected = ParsingException.class)
+    public void testMissingAnnotationHost() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fTest/testMissingAnnotationHost.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingAnnotationCluster() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingAnnotationCluster.json");
+        parseRecord("QueryLogParserV2fTest/testMissingAnnotationCluster.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testEmptyAnnotationService() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testEmptyAnnotationService.json");
+        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationService.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testEmptyAnnotationCluster() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testEmptyAnnotationCluster.json");
+        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationCluster.json");
     }
 
     @Test(expected = ParsingException.class)
-    public void testContainerNullId() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullId.json");
+    public void testEmptyAnnotationId() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationId.json");
     }
 
     @Test(expected = ParsingException.class)
-    public void testContainerMissingId() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingId.json");
+    public void testEmptyAnnotationHost() throws ParsingException, IOException {
+        parseRecord("QueryLogParserV2fTest/testEmptyAnnotationHost.json");
     }
 
     @Test
     public void testNullCounters() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNullCounters.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testNullCounters.json");
         Assert.assertNotNull(record);
     }
 
     @Test
     public void testNullTimers() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNullTimers.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testNullTimers.json");
         Assert.assertNotNull(record);
     }
 
     @Test
     public void testNullGauges() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNullGauges.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testNullGauges.json");
         Assert.assertNotNull(record);
     }
 
     @Test
     public void testMissingCounters() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testMissingCounters.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testMissingCounters.json");
         Assert.assertNotNull(record);
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
     @Test
     public void testMissingTimers() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testMissingTimers.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testMissingTimers.json");
         Assert.assertNotNull(record);
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
     @Test
     public void testMissingGauges() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testMissingGauges.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testMissingGauges.json");
         Assert.assertNotNull(record);
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
     @Test
     public void testEmptyValues() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testEmptyValues.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testEmptyValues.json");
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -210,233 +195,163 @@ public class QueryLogParserV2fStenoTest {
 
     @Test
     public void testUpperCaseVersion() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testUpperCaseVersion.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testUpperCaseVersion.json");
         Assert.assertNotNull(record);
     }
 
     @Test(expected = ParsingException.class)
-    public void testContainerMissingData() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingData.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerMissingLevel() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingLevel.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerMissingName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingName.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerMissingTime() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerMissingTime.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerNullData() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullData.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerNullLevel() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullLevel.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerNullName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullName.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerNullTime() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerNullTime.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerBadData() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerBadData.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerBadLevel() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerBadLevel.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerBadName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerBadName.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerBadTime() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerBadTime.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerBadContext() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerBadContext.json");
-    }
-
-    @Test(expected = ParsingException.class)
-    public void testContainerContextBadHost() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testContainerContextBadHost.json");
-    }
-
-    @Test(expected = ParsingException.class)
     public void testBadCounters() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounters.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounters.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimers() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimers.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimers.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGauges() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGauges.json");
+        parseRecord("QueryLogParserV2fTest/testBadGauges.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingGaugeValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingGaugeValues.json");
+        parseRecord("QueryLogParserV2fTest/testMissingGaugeValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingTimerValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingTimerValues.json");
+        parseRecord("QueryLogParserV2fTest/testMissingTimerValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingCounterValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingCounterValues.json");
+        parseRecord("QueryLogParserV2fTest/testMissingCounterValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testNullGaugeValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testNullGaugeValues.json");
+        parseRecord("QueryLogParserV2fTest/testNullGaugeValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testNullTimerValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testNullTimerValues.json");
+        parseRecord("QueryLogParserV2fTest/testNullTimerValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testNullCounterValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testNullCounterValues.json");
+        parseRecord("QueryLogParserV2fTest/testNullCounterValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValues.json");
+        parseRecord("QueryLogParserV2fTest/testBadGaugeValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValues.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimerValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValues() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValues.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounterValues.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingCounterValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingCounterValuesValue.json");
+        parseRecord("QueryLogParserV2fTest/testMissingCounterValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingGaugeValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingGaugeValuesValue.json");
+        parseRecord("QueryLogParserV2fTest/testMissingGaugeValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testMissingTimerValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testMissingTimerValuesValue.json");
+        parseRecord("QueryLogParserV2fTest/testMissingTimerValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValue.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValue.json");
+        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValue() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValue.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValue.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueNumeratorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueNumeratorUnits.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueNumeratorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueDenominatorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueDenominatorUnits.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueDenominatorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueNumeratorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueNumeratorUnits.json");
+        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueNumeratorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueDenominatorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueDenominatorUnits.json");
+        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueDenominatorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueNumeratorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueNumeratorUnits.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueNumeratorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueDenominatorUnits() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueDenominatorUnits.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueDenominatorUnits.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueNumeratorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueNumeratorUnitsName.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueNumeratorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadCounterValuesValueDenominatorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadCounterValuesValueDenominatorUnitsName.json");
+        parseRecord("QueryLogParserV2fTest/testBadCounterValuesValueDenominatorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueNumeratorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueNumeratorUnitsName.json");
+        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueNumeratorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadGaugeValuesValueDenominatorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadGaugeValuesValueDenominatorUnitsName.json");
+        parseRecord("QueryLogParserV2fTest/testBadGaugeValuesValueDenominatorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueNumeratorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueNumeratorUnitsName.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueNumeratorUnitsName.json");
     }
 
     @Test(expected = ParsingException.class)
     public void testBadTimerValuesValueDenominatorUnitsName() throws ParsingException, IOException {
-        parseRecord("QueryLogParserV2fStenoTest/testBadTimerValuesValueDenominatorUnitsName.json");
+        parseRecord("QueryLogParserV2fTest/testBadTimerValuesValueDenominatorUnitsName.json");
     }
 
     @Test
     public void testNaNValues() throws ParsingException, IOException {
-        final Record record = parseRecord("QueryLogParserV2fStenoTest/testNaNValues.json");
+        final Record record = parseRecord("QueryLogParserV2fTest/testNaNValues.json");
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
@@ -480,6 +395,6 @@ public class QueryLogParserV2fStenoTest {
         return new JsonToRecordParser.Builder()
                 .build()
                 .parse(Resources.toByteArray(Resources.getResource(
-                        QueryLogParserV2fStenoTest.class, fileName)));
+                        JsonToRecordParserV2fTest.class, fileName)));
     }
 }

--- a/src/test/java/com/arpnetworking/metrics/mad/performance/CollectdPipelinePT.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/performance/CollectdPipelinePT.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.mad.performance;
 import com.arpnetworking.test.junitbenchmarks.JsonBenchmarkConsumer;
 import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.apache.commons.io.IOUtils;
 import org.joda.time.Duration;
@@ -25,10 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -46,12 +44,7 @@ import java.util.zip.GZIPInputStream;
 public class CollectdPipelinePT extends FilePerfTestBase {
 
     @BeforeClass
-    public static void setUp() {
-        JSON_BENCHMARK_CONSUMER.prepareClass();
-    }
-
-    @Test
-    public void test() throws IOException, InterruptedException, URISyntaxException {
+    public static void setUp() throws IOException, URISyntaxException {
         // Extract the sample file
         final Path gzipPath = Paths.get(Resources.getResource("collectd-sample1.log.gz").toURI());
         final FileInputStream fileInputStream = new FileInputStream(gzipPath.toFile());
@@ -61,14 +54,22 @@ public class CollectdPipelinePT extends FilePerfTestBase {
 
         IOUtils.copy(gzipInputStream, outputStream);
 
-        benchmark(new File(Resources.getResource("collectd_sample1_pipeline.json").toURI()), Duration.standardMinutes(20));
+        JSON_BENCHMARK_CONSUMER.prepareClass();
+    }
+
+    @Test
+    public void test() throws IOException {
+        benchmark(
+                "collectd_sample1_pipeline.json",
+                Duration.standardMinutes(20),
+                ImmutableMap.of(
+                        "${SAMPLE_FILE}",
+                        "target/tmp/perf/collectd-sample1.log"));
     }
 
     @Rule
     public final TestRule _benchmarkRule = new BenchmarkRule(JSON_BENCHMARK_CONSUMER);
 
     private static final JsonBenchmarkConsumer JSON_BENCHMARK_CONSUMER = new JsonBenchmarkConsumer(
-            Paths.get("target/site/perf/benchmark-collectd-tsdagg.json"));
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationPipelinePT.class);
+            Paths.get("target/site/perf/benchmark-collectd-mad.json"));
 }

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/BaseSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/BaseSinkTest.java
@@ -62,7 +62,7 @@ public class BaseSinkTest {
         private static final class Builder extends BaseSink.Builder<Builder, TestAggregatedDataSink> {
 
             private Builder() {
-                super(TestAggregatedDataSink.class);
+                super(TestAggregatedDataSink::new);
             }
 
             @Override

--- a/src/test/resources/application_perf_pipeline.json
+++ b/src/test/resources/application_perf_pipeline.json
@@ -2,12 +2,12 @@
     "name": "application_pipeline",
     "sources": [
         {
-            "type": "com.arpnetworking.tsdcore.sources.FileSource",
+            "type": "com.arpnetworking.metrics.common.sources.FileSource",
             "name": "tsd_aggregator_query_log",
-            "sourceFile": "target/tmp/perf/application-generated-sample.log",
+            "sourceFile": "${SAMPLE_FILE}",
             "stateFile": null,
             "parser": {
-                "type": "com.arpnetworking.tsdaggregator.parsers.QueryLogParser",
+                "type": "com.arpnetworking.metrics.mad.parsers.JsonToRecordParser",
                 "defaultService": "test_service",
                 "defaultCluster": "test_cluster",
                 "defaultHost": "test_host.local"

--- a/src/test/resources/collectd_sample1_pipeline.json
+++ b/src/test/resources/collectd_sample1_pipeline.json
@@ -2,7 +2,7 @@
     "name": "collectd_pipeline",
     "sources": [
         {
-            "type": "com.arpnetworking.tsdaggregator.sources.MappingSource",
+            "type": "com.arpnetworking.metrics.mad.sources.MappingSource",
             "name": "collectd_mapping_source",
             "findAndReplace": {
                 "^cpu/([\\d]+)/cpu/([^/]+)/value": ["cpu/$2"],
@@ -23,12 +23,12 @@
                 "^tcpconns/([^-]+)-(local|remote)/tcp_connections/([^/]+)/value": ["tcpconns/$2/$1/$3"]
             },
             "source": {
-                "type": "com.arpnetworking.tsdcore.sources.FileSource",
+                "type": "com.arpnetworking.metrics.common.sources.FileSource",
                 "name": "collectd_source",
-                "sourceFile": "target/tmp/perf/collectd-sample1.log",
+                "sourceFile": "${SAMPLE_FILE}",
                 "stateFile": null,
                 "parser": {
-                    "type": "com.arpnetworking.tsdaggregator.parsers.QueryLogParser",
+                    "type": "com.arpnetworking.metrics.mad.parsers.JsonToRecordParser",
                     "defaultService": "collectd",
                     "defaultCluster": "test_cluster",
                     "defaultHost": "test_host.local"


### PR DESCRIPTION
Fixed the performance tests and separated test initialization from the actual test to provide more accurate cpu profiling. Upgraded dependenencies and migrated to build with constructor reference instead of reflection to improve performance. Still more work to be done here but this was a start.