### PR TITLE
Host, Service and Cluster to Annotations

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/mad/Aggregator.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/Aggregator.java
@@ -152,9 +152,9 @@ public final class Aggregator implements Observer, Launchable {
     private ImmutableMap<String, String> createDimensions(final Record record) {
         // TODO(ville): Promote user specified annotations to dimensions.
         final ImmutableMap.Builder<String, String> dimensionBuilder = ImmutableMap.builder();
-        dimensionBuilder.put(Key.HOST_DIMENSION_KEY, record.getHost());
-        dimensionBuilder.put(Key.SERVICE_DIMENSION_KEY, record.getService());
-        dimensionBuilder.put(Key.CLUSTER_DIMENSION_KEY, record.getCluster());
+        dimensionBuilder.put(Key.HOST_DIMENSION_KEY, record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        dimensionBuilder.put(Key.SERVICE_DIMENSION_KEY, record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        dimensionBuilder.put(Key.CLUSTER_DIMENSION_KEY, record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         return dimensionBuilder.build();
     }
 

--- a/src/main/java/com/arpnetworking/metrics/mad/model/Record.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/Record.java
@@ -15,9 +15,8 @@
  */
 package com.arpnetworking.metrics.mad.model;
 
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
-
-import java.util.Map;
 
 /**
  * The interface to a record. Records consistent of a timestamp, any number of
@@ -43,37 +42,16 @@ public interface Record {
     DateTime getTime();
 
     /**
-     * Gets the host of the record.
-     *
-     * @return the host.
-     */
-    String getHost();
-
-    /**
-     * Gets the service of the record.
-     *
-     * @return the service.
-     */
-    String getService();
-
-    /**
-     * Gets the cluster of the record.
-     *
-     * @return the cluster.
-     */
-    String getCluster();
-
-    /**
      * Gets metrics.
      *
      * @return the metrics
      */
-    Map<String, ? extends Metric> getMetrics();
+    ImmutableMap<String, ? extends Metric> getMetrics();
 
     /**
      * Gets annotations.
      *
      * @return the annotations
      */
-    Map<String, String> getAnnotations();
+    ImmutableMap<String, String> getAnnotations();
 }

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2e.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2e.java
@@ -415,7 +415,7 @@ public final class Version2e {
             return _finalTimestamp;
         }
 
-        public Map<String, String> getOtherAnnotations() {
+        public ImmutableMap<String, String> getOtherAnnotations() {
             return _otherAnnotations;
         }
 

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2f.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2f.java
@@ -294,19 +294,7 @@ public final class Version2f {
             return _id;
         }
 
-        public String getHost() {
-            return _host;
-        }
-
-        public String getCluster() {
-            return _cluster;
-        }
-
-        public String getService() {
-            return _service;
-        }
-
-        public Map<String, String> getOtherAnnotations() {
+        public ImmutableMap<String, String> getOtherAnnotations() {
             return _otherAnnotations;
         }
 
@@ -314,18 +302,12 @@ public final class Version2f {
             _start = builder._start;
             _end = builder._end;
             _id = builder._id;
-            _host = builder._host;
-            _cluster = builder._cluster;
-            _service = builder._service;
             _otherAnnotations = ImmutableMap.copyOf(builder._otherAnnotations);
         }
 
         private final DateTime _start;
         private final DateTime _end;
         private final String _id;
-        private final String _host;
-        private final String _cluster;
-        private final String _service;
         private final ImmutableMap<String, String> _otherAnnotations;
 
         /**
@@ -376,42 +358,6 @@ public final class Version2f {
             }
 
             /**
-             * Sets the host field.
-             *
-             * @param value Value
-             * @return This builder
-             */
-            @JsonSetter("_host")
-            public Annotations.Builder setHost(final String value) {
-                _host = value;
-                return this;
-            }
-
-            /**
-             * Sets the cluster field.
-             *
-             * @param value Value
-             * @return This builder
-             */
-            @JsonSetter("_cluster")
-            public Annotations.Builder setCluster(final String value) {
-                _cluster = value;
-                return this;
-            }
-
-            /**
-             * Sets the service field.
-             *
-             * @param value Value
-             * @return This builder
-             */
-            @JsonSetter("_service")
-            public Annotations.Builder setService(final String value) {
-                _service = value;
-                return this;
-            }
-
-            /**
              * Called by json deserialization to store non-member elements of
              * the json object. Stores the value in the otherAnnotations field.
              *
@@ -432,15 +378,6 @@ public final class Version2f {
             @NotEmpty
             @NotNull
             private String _id;
-            @NotEmpty
-            @NotNull
-            private String _host;
-            @NotEmpty
-            @NotNull
-            private String _cluster;
-            @NotEmpty
-            @NotNull
-            private String _service;
             @NotNull
             private final Map<String, String> _otherAnnotations = Maps.newHashMap();
         }

--- a/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2fSteno.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/json/Version2fSteno.java
@@ -495,14 +495,6 @@ public final class Version2fSteno {
             return _end;
         }
 
-        public String getCluster() {
-            return _cluster;
-        }
-
-        public String getService() {
-            return _service;
-        }
-
         public Map<String, String> getOtherAnnotations() {
             return _otherAnnotations;
         }
@@ -510,15 +502,11 @@ public final class Version2fSteno {
         private Annotations(final Annotations.Builder builder) {
             _start = builder._start;
             _end = builder._end;
-            _cluster = builder._cluster;
-            _service = builder._service;
             _otherAnnotations = ImmutableMap.copyOf(builder._otherAnnotations);
         }
 
         private final DateTime _start;
         private final DateTime _end;
-        private final String _cluster;
-        private final String _service;
         private final ImmutableMap<String, String> _otherAnnotations;
 
         /**
@@ -557,30 +545,6 @@ public final class Version2fSteno {
             }
 
             /**
-             * Sets the cluster field.
-             *
-             * @param value Value
-             * @return This builder
-             */
-            @JsonSetter("_cluster")
-            public Annotations.Builder setCluster(final String value) {
-                _cluster = value;
-                return this;
-            }
-
-            /**
-             * Sets the service field.
-             *
-             * @param value Value
-             * @return This builder
-             */
-            @JsonSetter("_service")
-            public Annotations.Builder setService(final String value) {
-                _service = value;
-                return this;
-            }
-
-            /**
              * Called by json deserialization to store non-member elements of
              * the json object. Stores the value in the otherAnnotations field.
              *
@@ -598,12 +562,6 @@ public final class Version2fSteno {
             private DateTime _start;
             @NotNull
             private DateTime _end;
-            @NotEmpty
-            @NotNull
-            private String _cluster;
-            @NotEmpty
-            @NotNull
-            private String _service;
             @NotNull
             private final Map<String, String> _otherAnnotations = Maps.newHashMap();
         }

--- a/src/main/java/com/arpnetworking/metrics/mad/sources/MappingSource.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/sources/MappingSource.java
@@ -32,6 +32,7 @@ import com.arpnetworking.tsdcore.model.MetricType;
 import com.arpnetworking.tsdcore.model.Quantity;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.sf.oval.constraint.NotNull;
@@ -95,7 +96,7 @@ public final class MappingSource extends BaseSource {
 
         _findAndReplace = Maps.newHashMapWithExpectedSize(builder._findAndReplace.size());
         for (final Map.Entry<String, ? extends List<String>> entry : builder._findAndReplace.entrySet()) {
-            _findAndReplace.put(Pattern.compile(entry.getKey()), ImmutableList.<String>copyOf(entry.getValue()));
+            _findAndReplace.put(Pattern.compile(entry.getKey()), ImmutableList.copyOf(entry.getValue()));
         }
 
         _source.attach(new MappingObserver(this, _findAndReplace));
@@ -149,14 +150,16 @@ public final class MappingSource extends BaseSource {
             _source.notify(
                     new DefaultRecord.Builder()
                             .setMetrics(
-                                    Maps.transformEntries(
-                                            mergedMetrics,
-                                            (key, mergingMetric) -> OvalBuilder.clone(mergingMetric, new DefaultMetric.Builder()).build()))
+                                    ImmutableMap.copyOf(
+                                            Maps.<String, MergingMetric, Metric>transformEntries(
+                                                    mergedMetrics,
+                                                    (key, mergingMetric) ->
+                                                            OvalBuilder.clone(
+                                                                    mergingMetric,
+                                                                    new DefaultMetric.Builder())
+                                                            .build())))
                             .setId(record.getId())
                             .setTime(record.getTime())
-                            .setCluster(record.getCluster())
-                            .setService(record.getService())
-                            .setHost(record.getHost())
                             .setAnnotations(record.getAnnotations())
                             .build());
         }

--- a/src/test/java/com/arpnetworking/metrics/mad/AggregatorTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/AggregatorTest.java
@@ -83,7 +83,7 @@ public class AggregatorTest {
         _aggregator.notify(
                 null,
                 new DefaultRecord.Builder()
-                        .setMetrics(Collections.singletonMap(
+                        .setMetrics(ImmutableMap.of(
                                 "MyMetric",
                                 new DefaultMetric.Builder()
                                         .setType(MetricType.GAUGE)
@@ -92,9 +92,11 @@ public class AggregatorTest {
                                         .build()))
                         .setTime(dataTimeInThePast)
                         .setId(UUID.randomUUID().toString())
-                        .setCluster("MyCluster")
-                        .setService("MyService")
-                        .setHost("MyHost")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .build());
 
         // Wait for the period to close
@@ -132,7 +134,11 @@ public class AggregatorTest {
                 null,
                 TestBeanFactory.createRecordBuilder()
                         .setTime(start)
-                        .setCluster("MyClusterA")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyClusterA"))
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
                                 new DefaultMetric.Builder()
@@ -145,7 +151,11 @@ public class AggregatorTest {
                 null,
                 TestBeanFactory.createRecordBuilder()
                         .setTime(start)
-                        .setCluster("MyClusterB")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyClusterB"))
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
                                 new DefaultMetric.Builder()
@@ -204,7 +214,11 @@ public class AggregatorTest {
                 null,
                 TestBeanFactory.createRecordBuilder()
                         .setTime(start)
-                        .setService("MyServiceA")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyServiceA",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
                                 new DefaultMetric.Builder()
@@ -217,7 +231,11 @@ public class AggregatorTest {
                 null,
                 TestBeanFactory.createRecordBuilder()
                         .setTime(start)
-                        .setService("MyServiceB")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyServiceB",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
                                 new DefaultMetric.Builder()
@@ -276,7 +294,11 @@ public class AggregatorTest {
                 null,
                 TestBeanFactory.createRecordBuilder()
                         .setTime(start)
-                        .setHost("MyHostA")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHostA",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
                                 new DefaultMetric.Builder()
@@ -289,7 +311,11 @@ public class AggregatorTest {
                 null,
                 TestBeanFactory.createRecordBuilder()
                         .setTime(start)
-                        .setHost("MyHostB")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHostB",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
                                 new DefaultMetric.Builder()

--- a/src/test/java/com/arpnetworking/metrics/mad/BucketTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/BucketTest.java
@@ -115,9 +115,11 @@ public class BucketTest {
         _bucket.add(
                 new DefaultRecord.Builder()
                         .setTime(START.plus(Duration.standardSeconds(10)))
-                        .setCluster("MyCluster")
-                        .setService("MyService")
-                        .setHost("MyHost")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .setId(UUID.randomUUID().toString())
                         .setMetrics(ImmutableMap.of(
                                 "MyCounter",
@@ -233,9 +235,11 @@ public class BucketTest {
         _bucket.add(
                 new DefaultRecord.Builder()
                         .setTime(START.plus(Duration.standardSeconds(offset)))
-                        .setCluster("MyCluster")
-                        .setService("MyService")
-                        .setHost("MyHost")
+                        .setAnnotations(
+                                ImmutableMap.of(
+                                        Key.HOST_DIMENSION_KEY, "MyHost",
+                                        Key.SERVICE_DIMENSION_KEY, "MyService",
+                                        Key.CLUSTER_DIMENSION_KEY, "MyCluster"))
                         .setId(UUID.randomUUID().toString())
                         .setMetrics(ImmutableMap.of(
                                 name,

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/CollectdJsonToRecordParserTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/CollectdJsonToRecordParserTest.java
@@ -19,6 +19,7 @@ import com.arpnetworking.metrics.common.parsers.exceptions.ParsingException;
 import com.arpnetworking.metrics.mad.model.HttpRequest;
 import com.arpnetworking.metrics.mad.model.Metric;
 import com.arpnetworking.metrics.mad.model.Record;
+import com.arpnetworking.tsdcore.model.Key;
 import com.arpnetworking.tsdcore.model.MetricType;
 import com.arpnetworking.tsdcore.model.Quantity;
 import com.google.common.collect.ImmutableMultimap;
@@ -47,9 +48,9 @@ public class CollectdJsonToRecordParserTest {
 
         Assert.assertEquals(18, records.size());
         final Record record = records.get(0);
-        Assert.assertEquals("host.example.com", record.getHost());
-        Assert.assertEquals("MyService", record.getService());
-        Assert.assertEquals("MyCluster", record.getCluster());
+        Assert.assertEquals("host.example.com", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         verifyMetric(records,
                 DateTime.parse("2016-03-31T23:14:46.740Z"),
                 "cpu/0/cpu/wait",

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2cTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2cTest.java
@@ -19,6 +19,7 @@ package com.arpnetworking.metrics.mad.parsers;
 import com.arpnetworking.metrics.common.parsers.exceptions.ParsingException;
 import com.arpnetworking.metrics.mad.model.Metric;
 import com.arpnetworking.metrics.mad.model.Record;
+import com.arpnetworking.tsdcore.model.Key;
 import com.arpnetworking.tsdcore.model.MetricType;
 import com.arpnetworking.tsdcore.model.Quantity;
 import com.google.common.base.Strings;
@@ -46,9 +47,9 @@ public class JsonToRecordParserV2cTest {
         final Record record = parseRecord("QueryLogParserV2cTest/testParse.json");
 
         Assert.assertNotNull(record);
-        Assert.assertEquals("MyCluster", record.getCluster());
-        Assert.assertEquals("MyService", record.getService());
-        Assert.assertEquals("MyHost", record.getHost());
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> map = record.getMetrics();
         Assert.assertEquals(5, map.size());
@@ -93,7 +94,10 @@ public class JsonToRecordParserV2cTest {
         final Record record = parseRecord("QueryLogParserV2cTest/testAnnotations.json");
 
         Assert.assertNotNull(record);
-        Assert.assertEquals(2, record.getAnnotations().size());
+        Assert.assertEquals(5, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         Assert.assertThat(record.getAnnotations(), IsMapContaining.hasEntry("method", "POST"));
         Assert.assertThat(record.getAnnotations(), IsMapContaining.hasEntry("request_id", "c5251254-8f7c-4c21-95da-270eb66e100b"));
     }
@@ -278,20 +282,23 @@ public class JsonToRecordParserV2cTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(new DateTime((long) (1347527687.686 * 1000d), ISOChronology.getInstanceUTC()), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("t1"));
+        Assert.assertThat(variables, Matchers.hasKey("t1"));
         final Metric t1 = variables.get("t1");
         Assert.assertTrue(t1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("g1"));
+        Assert.assertThat(variables, Matchers.hasKey("g1"));
         final Metric g1 = variables.get("g1");
         Assert.assertTrue(g1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("c1"));
+        Assert.assertThat(variables, Matchers.hasKey("c1"));
         final Metric c1 = variables.get("c1");
         Assert.assertTrue(c1.getValues().isEmpty());
     }
@@ -304,7 +311,7 @@ public class JsonToRecordParserV2cTest {
                 .build()
                 .parse(Resources.toByteArray(
                         Resources.getResource(JsonToRecordParserV2cTest.class, "QueryLogParserV2cTest/testDefaultHostname.json")));
-        Assert.assertFalse(Strings.isNullOrEmpty(record.getHost()));
+        Assert.assertFalse(Strings.isNullOrEmpty(record.getAnnotations().get(Key.HOST_DIMENSION_KEY)));
 
     }
 

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2dTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2dTest.java
@@ -19,6 +19,7 @@ package com.arpnetworking.metrics.mad.parsers;
 import com.arpnetworking.metrics.common.parsers.exceptions.ParsingException;
 import com.arpnetworking.metrics.mad.model.Metric;
 import com.arpnetworking.metrics.mad.model.Record;
+import com.arpnetworking.tsdcore.model.Key;
 import com.arpnetworking.tsdcore.model.Unit;
 import com.google.common.io.Resources;
 
@@ -42,9 +43,9 @@ public class JsonToRecordParserV2dTest {
     public void testParse() throws ParsingException, IOException {
         final Record record = parseRecord("QueryLogParserV2dTest/testParse.json");
         Assert.assertNotNull(record);
-        Assert.assertEquals("MyCluster", record.getCluster());
-        Assert.assertEquals("MyService", record.getService());
-        Assert.assertEquals("MyHost", record.getHost());
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
 
@@ -72,7 +73,10 @@ public class JsonToRecordParserV2dTest {
         final Record record = parseRecord("QueryLogParserV2dTest/testAnnotations.json");
         Assert.assertNotNull(record);
 
-        Assert.assertEquals(2, record.getAnnotations().size());
+        Assert.assertEquals(5, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         Assert.assertThat(record.getAnnotations(), IsMapContaining.hasEntry("method", "POST"));
         Assert.assertThat(record.getAnnotations(), IsMapContaining.hasEntry("request_id", "c5251254-8f7c-4c21-95da-270eb66e100b"));
     }
@@ -94,20 +98,23 @@ public class JsonToRecordParserV2dTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("t1"));
+        Assert.assertThat(variables, Matchers.hasKey("t1"));
         final Metric t1 = variables.get("t1");
         Assert.assertTrue(t1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("g1"));
+        Assert.assertThat(variables, Matchers.hasKey("g1"));
         final Metric g1 = variables.get("g1");
         Assert.assertTrue(g1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("c1"));
+        Assert.assertThat(variables, Matchers.hasKey("c1"));
         final Metric c1 = variables.get("c1");
         Assert.assertTrue(c1.getValues().isEmpty());
     }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2eTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2eTest.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.mad.parsers;
 import com.arpnetworking.metrics.common.parsers.exceptions.ParsingException;
 import com.arpnetworking.metrics.mad.model.Metric;
 import com.arpnetworking.metrics.mad.model.Record;
+import com.arpnetworking.tsdcore.model.Key;
 import com.arpnetworking.tsdcore.model.Quantity;
 import com.arpnetworking.tsdcore.model.Unit;
 import com.google.common.base.Optional;
@@ -42,9 +43,9 @@ public class JsonToRecordParserV2eTest {
     public void testParse() throws ParsingException, IOException {
         final Record record = parseRecord("QueryLogParserV2eTest/testParse.json");
         Assert.assertNotNull(record);
-        Assert.assertEquals("MyCluster", record.getCluster());
-        Assert.assertEquals("MyService", record.getService());
-        Assert.assertEquals("MyHost", record.getHost());
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
 
@@ -83,7 +84,10 @@ public class JsonToRecordParserV2eTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
@@ -111,7 +115,10 @@ public class JsonToRecordParserV2eTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
@@ -135,20 +142,23 @@ public class JsonToRecordParserV2eTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("t1"));
+        Assert.assertThat(variables, Matchers.hasKey("t1"));
         final Metric t1 = variables.get("t1");
         Assert.assertTrue(t1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("g1"));
+        Assert.assertThat(variables, Matchers.hasKey("g1"));
         final Metric g1 = variables.get("g1");
         Assert.assertTrue(g1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("c1"));
+        Assert.assertThat(variables, Matchers.hasKey("c1"));
         final Metric c1 = variables.get("c1");
         Assert.assertTrue(c1.getValues().isEmpty());
     }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fStenoTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fStenoTest.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.mad.parsers;
 import com.arpnetworking.metrics.common.parsers.exceptions.ParsingException;
 import com.arpnetworking.metrics.mad.model.Metric;
 import com.arpnetworking.metrics.mad.model.Record;
+import com.arpnetworking.tsdcore.model.Key;
 import com.arpnetworking.tsdcore.model.Quantity;
 import com.arpnetworking.tsdcore.model.Unit;
 import com.google.common.base.Optional;
@@ -43,9 +44,9 @@ public class JsonToRecordParserV2fStenoTest {
 
         final Record record = parseRecord("QueryLogParserV2fStenoTest/testParse.json");
         Assert.assertNotNull(record);
-        Assert.assertEquals("MyCluster", record.getCluster());
-        Assert.assertEquals("MyService", record.getService());
-        Assert.assertEquals("MyHost", record.getHost());
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
         Assert.assertEquals("oRw59PrARvatGNC7fiWw4A", record.getId());
         Assert.assertFalse(record.getId().isEmpty());
 
@@ -86,7 +87,10 @@ public class JsonToRecordParserV2fStenoTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
@@ -190,7 +194,10 @@ public class JsonToRecordParserV2fStenoTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
@@ -440,20 +447,23 @@ public class JsonToRecordParserV2fStenoTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("t1"));
+        Assert.assertThat(variables, Matchers.hasKey("t1"));
         final Metric t1 = variables.get("t1");
         Assert.assertTrue(t1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("g1"));
+        Assert.assertThat(variables, Matchers.hasKey("g1"));
         final Metric g1 = variables.get("g1");
         Assert.assertTrue(g1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("c1"));
+        Assert.assertThat(variables, Matchers.hasKey("c1"));
         final Metric c1 = variables.get("c1");
         Assert.assertTrue(c1.getValues().isEmpty());
     }

--- a/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/parsers/JsonToRecordParserV2fTest.java
@@ -18,6 +18,7 @@ package com.arpnetworking.metrics.mad.parsers;
 import com.arpnetworking.metrics.common.parsers.exceptions.ParsingException;
 import com.arpnetworking.metrics.mad.model.Metric;
 import com.arpnetworking.metrics.mad.model.Record;
+import com.arpnetworking.tsdcore.model.Key;
 import com.arpnetworking.tsdcore.model.Quantity;
 import com.arpnetworking.tsdcore.model.Unit;
 import com.google.common.base.Optional;
@@ -43,9 +44,9 @@ public class JsonToRecordParserV2fTest {
 
         final Record record = parseRecord("QueryLogParserV2fTest/testParse.json");
         Assert.assertNotNull(record);
-        Assert.assertEquals("MyCluster", record.getCluster());
-        Assert.assertEquals("MyService", record.getService());
-        Assert.assertEquals("MyHost", record.getHost());
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
         Assert.assertEquals("6be33313-bb39-423a-a928-1d0cc0da60a9", record.getId());
         Assert.assertFalse(record.getId().isEmpty());
 
@@ -86,7 +87,10 @@ public class JsonToRecordParserV2fTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
         Assert.assertTrue(record.getMetrics().isEmpty());
     }
 
@@ -175,7 +179,10 @@ public class JsonToRecordParserV2fTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
@@ -355,20 +362,23 @@ public class JsonToRecordParserV2fTest {
         Assert.assertNotNull(record);
 
         Assert.assertEquals(DateTime.parse("2014-03-24T12:15:41.010Z"), record.getTime());
-        Assert.assertTrue(record.getAnnotations().isEmpty());
+        Assert.assertEquals(3, record.getAnnotations().size());
+        Assert.assertEquals("MyHost", record.getAnnotations().get(Key.HOST_DIMENSION_KEY));
+        Assert.assertEquals("MyService", record.getAnnotations().get(Key.SERVICE_DIMENSION_KEY));
+        Assert.assertEquals("MyCluster", record.getAnnotations().get(Key.CLUSTER_DIMENSION_KEY));
 
         final Map<String, ? extends Metric> variables = record.getMetrics();
         Assert.assertEquals(3, variables.size());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("t1"));
+        Assert.assertThat(variables, Matchers.hasKey("t1"));
         final Metric t1 = variables.get("t1");
         Assert.assertTrue(t1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("g1"));
+        Assert.assertThat(variables, Matchers.hasKey("g1"));
         final Metric g1 = variables.get("g1");
         Assert.assertTrue(g1.getValues().isEmpty());
 
-        Assert.assertThat(variables, Matchers.<String>hasKey("c1"));
+        Assert.assertThat(variables, Matchers.hasKey("c1"));
         final Metric c1 = variables.get("c1");
         Assert.assertTrue(c1.getValues().isEmpty());
     }

--- a/src/test/java/com/arpnetworking/metrics/mad/sources/MappingSourceTest.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/sources/MappingSourceTest.java
@@ -133,7 +133,6 @@ public class MappingSourceTest {
     @Test
     public void testMergeTwoGauges() {
         final Record matchingRecord = TestBeanFactory.createRecordBuilder()
-                .setAnnotations(Collections.singletonMap("key", "value"))
                 .setMetrics(ImmutableMap.of(
                         "foo/1/bar",
                         TestBeanFactory.createMetricBuilder()
@@ -242,7 +241,6 @@ public class MappingSourceTest {
     @Test
     public void testReplaceWithCapture() {
         final Record matchingRecord = TestBeanFactory.createRecordBuilder()
-                .setAnnotations(Collections.singletonMap("key", "value"))
                 .setMetrics(ImmutableMap.of(
                         "cat/sheep/dog",
                         TestBeanFactory.createMetricBuilder()
@@ -285,7 +283,6 @@ public class MappingSourceTest {
     @Test
     public void testMultipleMatches() {
         final Record matchingRecord = TestBeanFactory.createRecordBuilder()
-                .setAnnotations(Collections.singletonMap("key", "value"))
                 .setMetrics(ImmutableMap.of(
                         "cat/bear/dog",
                         TestBeanFactory.createMetricBuilder()

--- a/src/test/java/com/arpnetworking/test/TestBeanFactory.java
+++ b/src/test/java/com/arpnetworking/test/TestBeanFactory.java
@@ -57,15 +57,17 @@ public final class TestBeanFactory {
      */
     public static DefaultRecord.Builder createRecordBuilder() {
         return new DefaultRecord.Builder()
-                .setMetrics(Collections.singletonMap(
-                        "foo/bar",
-                        createMetric()))
+                .setMetrics(
+                        ImmutableMap.of(
+                                "foo/bar",
+                                createMetric()))
                 .setTime(new DateTime())
                 .setId(UUID.randomUUID().toString())
-                .setCluster("MyCluster")
-                .setService("MyService")
-                .setHost("MyHost")
-                .setAnnotations(Collections.<String, String>emptyMap());
+                .setAnnotations(
+                        ImmutableMap.of(
+                                Key.HOST_DIMENSION_KEY, "MyHost",
+                                Key.SERVICE_DIMENSION_KEY, "MyService",
+                                Key.CLUSTER_DIMENSION_KEY, "MyCluster"));
     }
 
     /**


### PR DESCRIPTION
Moved host, service and cluster from Record attributes into Record annotations. User annotations by the same names will be suppressed.