### PR TITLE
Skip Docker Start/Stop with Integration Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,9 @@
             <goals>
               <goal>start</goal>
             </goals>
+            <configuration>
+              <skip>${skipIntegrationTests}</skip>
+            </configuration>
           </execution>
           <execution>
             <id>stop</id>
@@ -296,6 +299,9 @@
             <goals>
               <goal>stop</goal>
             </goals>
+            <configuration>
+              <skip>${skipIntegrationTests}</skip>
+            </configuration>
           </execution>
           <execution>
             <id>push</id>


### PR DESCRIPTION
Added configuration to docker plugin to skip start and stop if integration tests are being skipped.