### PR TITLE
fix concurrency problem with telemetry actors/messages

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/proxy/actors/Telemetry.java
+++ b/src/main/java/com/arpnetworking/metrics/proxy/actors/Telemetry.java
@@ -37,6 +37,7 @@ import com.arpnetworking.metrics.proxy.models.messages.NewMetric;
 import com.arpnetworking.steno.LogValueMapFactory;
 import com.arpnetworking.steno.Logger;
 import com.arpnetworking.steno.LoggerFactory;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
@@ -207,7 +208,7 @@ public class Telemetry extends UntypedActor {
         _metrics.incrementCounter(METRICS_LIST_REQUEST);
 
         // Transmit a list of all registered metrics
-        getSender().tell(new MetricsList(_serviceMetrics), getSelf());
+        getSender().tell(new MetricsList(ImmutableMap.copyOf(_serviceMetrics)), getSelf());
     }
 
     private void registerLog(final Path logPath) {

--- a/src/main/java/com/arpnetworking/metrics/proxy/models/messages/MetricsList.java
+++ b/src/main/java/com/arpnetworking/metrics/proxy/models/messages/MetricsList.java
@@ -19,6 +19,7 @@ package com.arpnetworking.metrics.proxy.models.messages;
 import com.arpnetworking.logback.annotations.Loggable;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.Set;
@@ -38,7 +39,7 @@ public final class MetricsList {
      *
      * @param metrics Metrics map
      */
-    public MetricsList(final Map<String, Map<String, Set<String>>> metrics) {
+    public MetricsList(final ImmutableMap<String, Map<String, Set<String>>> metrics) {
         _metrics = metrics;
     }
 
@@ -60,5 +61,5 @@ public final class MetricsList {
                 .toString();
     }
 
-    private final Map<String, Map<String, Set<String>>> _metrics;
+    private final ImmutableMap<String, Map<String, Set<String>>> _metrics;
 }


### PR DESCRIPTION
Had this little gem blow up on me today.  The root of the problem is that the map is passed into a message and sent to the connection message processors.  This causes a concurrent modification exception when new metrics are being sent created while the metrics list is being walked to send to a websocket client.