### PR TITLE
Update PipelineConfiguration.java

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/mad/configuration/PipelineConfiguration.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/configuration/PipelineConfiguration.java
@@ -265,7 +265,7 @@ public final class PipelineConfiguration {
         @NotNull
         @NotEmpty
         private Set<Statistic> _timerStatistics = Sets.<Statistic>newHashSet(
-                STATISTIC_FACTORY.getStatistic("mean"),
+                STATISTIC_FACTORY.getStatistic("median"),
                 STATISTIC_FACTORY.getStatistic("tp90"),
                 STATISTIC_FACTORY.getStatistic("tp99"),
                 STATISTIC_FACTORY.getStatistic("mean"),


### PR DESCRIPTION
Looks like mean is added twice to the set; I bet we meant median for the other entry. Should we set it to median or drop it entirely? The latter is completely backwards compatible.