### PR TITLE
Add host name resolver to Vertx sink.

### DIFF
--- a/src/main/java/com/arpnetworking/utility/DefaultHostNameResolver.java
+++ b/src/main/java/com/arpnetworking/utility/DefaultHostNameResolver.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Inscope Metrics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.utility;
+
+/**
+ * Resolves the host name by returning it without modification.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+public final class DefaultHostNameResolver implements HostNameResolver {
+
+    @Override
+    public String resolve(final String hostname) {
+        return hostname;
+    }
+}

--- a/src/main/java/com/arpnetworking/utility/HostNameResolver.java
+++ b/src/main/java/com/arpnetworking/utility/HostNameResolver.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 Inscope Metrics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.arpnetworking.utility;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Interface for classes which resolve host names. This is commonly used
+ * to inject a service discovery or load balancing strategy that is not
+ * supported transparently through DNS lookup.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.CLASS,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+public interface HostNameResolver {
+
+    /**
+     * Resolve a host name to another hostname or ip address.
+     *
+     * @param hostName the host name to resolve.
+     * @return the resolved host name or ip address.
+     */
+    String resolve(final String hostName);
+}


### PR DESCRIPTION
This change allows MAD to connect to CAGG with a custom service discovery layer resolving the configured host "address". By default no resolution is performed and the configured address is used as-is. Since CAGG periodically disconnects MAD clients this should rotate and load balance nicely across a discoverable pool of CAGG hosts.

FYI. @ddimensia 