### PR TITLE
Update docker maven plugin to 0.26.0 to resolve `JSONObject["auth"] not found` issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <!-- Additional Plugins -->
     <aspectjtools.maven.plugin>1.8.9</aspectjtools.maven.plugin>
     <aspectj.maven.plugin.version>1.8</aspectj.maven.plugin.version>
-    <docker.maven.plugin.version>0.16.7</docker.maven.plugin.version>
+    <docker.maven.plugin.version>0.26.0</docker.maven.plugin.version>
     <javassist.maven.plugin.version>0.1.2</javassist.maven.plugin.version>
     <maven.assembly.plugin.version>2.6</maven.assembly.plugin.version>
     <rpm.maven.plugin.version>2.1.5</rpm.maven.plugin.version>


### PR DESCRIPTION
When running './jdkwrapper.sh ./mvnw package' with the current source on OSX I got an error with the docker-maven-plugin related saying `JSONObject["auth"] not found.`.  When searching for this failure I came across https://github.com/fabric8io/docker-maven-plugin/issues/534 which indicated newer versions of the plugin had addressed the issue.  

Updating the plugin version did indeed resolve the problem.