### PR TITLE
Changed references to 'target' directory to used the buildDirectory property instead.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -716,7 +716,7 @@
                   <parallel combine.self="override" />
                   <forkCount>1</forkCount>
                   <reuseForks>false</reuseForks>
-                  <argLine>-agentlib:hprof=cpu=samples,depth=15,interval=5,force=y,file=${basedir}/target/perf.profile.hprof.txt</argLine>
+                  <argLine>-agentlib:hprof=cpu=samples,depth=15,interval=5,force=y,file=${buildDirectory}/perf.profile.hprof.txt</argLine>
                 </configuration>
               </execution>
             </executions>

--- a/src/main/assembly/bin.xml
+++ b/src/main/assembly/bin.xml
@@ -30,7 +30,7 @@
             <fileMode>0644</fileMode>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/target/appassembler/bin</directory>
+            <directory>${buildDirectory}/appassembler/bin</directory>
             <outputDirectory>bin</outputDirectory>
             <fileMode>0755</fileMode>
             <includes>
@@ -38,7 +38,7 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>${project.basedir}/target/appassembler/lib</directory>
+            <directory>${buildDirectory}/appassembler/lib</directory>
             <outputDirectory>lib</outputDirectory>
             <fileMode>0644</fileMode>
         </fileSet>

--- a/src/main/assembly/docker.xml
+++ b/src/main/assembly/docker.xml
@@ -39,7 +39,7 @@
       <fileMode>0644</fileMode>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/target/appassembler/bin</directory>
+      <directory>${buildDirectory}/appassembler/bin</directory>
       <outputDirectory>bin</outputDirectory>
       <fileMode>0755</fileMode>
       <includes>
@@ -47,7 +47,7 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/target/appassembler/lib</directory>
+      <directory>${buildDirectory}/appassembler/lib</directory>
       <outputDirectory>lib</outputDirectory>
       <fileMode>0644</fileMode>
       <includes>
@@ -55,7 +55,7 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${project.basedir}/target/appassembler/lib</directory>
+      <directory>${buildDirectory}/appassembler/lib</directory>
       <outputDirectory>deps</outputDirectory>
       <fileMode>0644</fileMode>
       <excludes>


### PR DESCRIPTION
When I added the 'buildDirectory' property for allowing the build output to be something other than 'target' I missed a few places that were using ${project.basedir}/target to find build artifacts.  

I went through all of the files and converted references to ${project.basedir}/target to use ${buildDirectory} instead. 