### PR TITLE
Allow the configuration to customize the monitoring service.

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/mad/Main.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/Main.java
@@ -260,7 +260,7 @@ public final class Main implements Launchable {
                         + _configuration.getMetricsClientPort() + "/metrics/v2/application");
         final MetricsFactory metricsFactory = new TsdMetricsFactory.Builder()
                 .setClusterName(_configuration.getMonitoringCluster())
-                .setServiceName("mad")
+                .setServiceName(_configuration.getMonitoringService())
                 .setSinks(
                         Collections.singletonList(
                                 new ApacheHttpSink.Builder()

--- a/src/main/java/com/arpnetworking/metrics/mad/configuration/AggregatorConfiguration.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/configuration/AggregatorConfiguration.java
@@ -41,6 +41,10 @@ public final class AggregatorConfiguration {
         return _monitoringCluster;
     }
 
+    public String getMonitoringService() {
+        return _monitoringService;
+    }
+
     public File getLogDirectory() {
         return _logDirectory;
     }
@@ -90,6 +94,7 @@ public final class AggregatorConfiguration {
         return MoreObjects.toStringHelper(this)
                 .add("id", Integer.toHexString(System.identityHashCode(this)))
                 .add("MonitoringCluster", _monitoringCluster)
+                .add("MonitoringService", _monitoringService)
                 .add("LogDirectory", _logDirectory)
                 .add("PipelinesDirectory", _pipelinesDirectory)
                 .add("HttpHost", _httpHost)
@@ -106,6 +111,7 @@ public final class AggregatorConfiguration {
 
     private AggregatorConfiguration(final Builder builder) {
         _monitoringCluster = builder._monitoringCluster;
+        _monitoringService = builder._monitoringService;
         _logDirectory = builder._logDirectory;
         _pipelinesDirectory = builder._pipelinesDirectory;
         _httpHost = builder._httpHost;
@@ -121,6 +127,7 @@ public final class AggregatorConfiguration {
     }
 
     private final String _monitoringCluster;
+    private final String _monitoringService;
     private final File _logDirectory;
     private final File _pipelinesDirectory;
     private final String _httpHost;
@@ -155,6 +162,18 @@ public final class AggregatorConfiguration {
          */
         public Builder setMonitoringCluster(final String value) {
             _monitoringCluster = value;
+            return this;
+        }
+
+        /**
+         * The monitoring service. Optional. Cannot be null or empty. The
+         * default value is {@code mad}.
+         *
+         * @param value The monitoring service.
+         * @return This instance of <code>Builder</code>.
+         */
+        public Builder setMonitoringService(final String value) {
+            _monitoringService = value;
             return this;
         }
 
@@ -292,6 +311,9 @@ public final class AggregatorConfiguration {
         @NotNull
         @NotEmpty
         private String _monitoringCluster;
+        @NotNull
+        @NotEmpty
+        private String _monitoringService = "mad";
         @NotNull
         private File _logDirectory;
         @NotNull


### PR DESCRIPTION
Currently we are running two MAD instances on one of our fleets - clusters - where one instance is used to monitoring and aggregate the local services and the other is used for aggregating remote sample feeds. Since both are on the same cluster we need to customize one of the service names in order to separate out the metrics about metrics.