### PR TITLE
MAD-2.0 Minor Fixes

### DIFF
--- a/src/main/java/com/inscopemetrics/mad/sinks/DimensionInjectingSink.java
+++ b/src/main/java/com/inscopemetrics/mad/sinks/DimensionInjectingSink.java
@@ -15,6 +15,7 @@
  */
 package com.inscopemetrics.mad.sinks;
 
+import com.arpnetworking.commons.builder.ThreadLocalBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.inscopemetrics.mad.model.DefaultKey;
@@ -38,9 +39,11 @@ public final class DimensionInjectingSink extends BaseSink {
         final Map<String, String> mergedDimensions = Maps.newHashMap(_defaultDimensions);
         mergedDimensions.putAll(data.getDimensions().getParameters());
         mergedDimensions.putAll(_overrideDimensions);
-        final PeriodicData.Builder dataBuilder = PeriodicData.Builder.clone(data);
-        dataBuilder.setDimensions(new DefaultKey(ImmutableMap.copyOf(mergedDimensions)));
-        _sink.recordAggregateData(dataBuilder.build());
+        final PeriodicData updatedData = ThreadLocalBuilder.clone(
+                data,
+                PeriodicData.Builder.class,
+                b -> b.setDimensions(new DefaultKey(ImmutableMap.copyOf(mergedDimensions))));
+        _sink.recordAggregateData(updatedData);
     }
 
     /**

--- a/src/main/java/com/inscopemetrics/mad/sinks/TelemetrySink.java
+++ b/src/main/java/com/inscopemetrics/mad/sinks/TelemetrySink.java
@@ -32,8 +32,8 @@ import com.inscopemetrics.mad.statistics.Statistic;
 import com.inscopemetrics.mad.telemetry.actors.TelemetryActor;
 import net.sf.oval.constraint.NotNull;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * A publisher that sends a message to the {@link TelemetryActor} actor.
@@ -62,7 +62,7 @@ public final class TelemetrySink extends BaseSink {
     public Object toLogValue() {
         return LogValueMapFactory.builder(this)
                 .put("super", super.toLogValue())
-                .put("telemetryActor", _telemetryActor)
+                .put("telemetryActor", getTelemetryActor())
                 .build();
     }
 

--- a/src/main/java/com/inscopemetrics/mad/sources/TelegrafJsonTcpSource.java
+++ b/src/main/java/com/inscopemetrics/mad/sources/TelegrafJsonTcpSource.java
@@ -133,7 +133,7 @@ public final class TelegrafJsonTcpSource extends TcpLineSource {
         @NotNull
         private TimestampUnit _timestampUnit = TimestampUnit.SECONDS;
 
-        private static final int DEFAULT_PORT = 2003;
+        private static final int DEFAULT_PORT = 8094;
         private static final String DEFAULT_NAME = "telegraf_json_tcp_source";
     }
 }

--- a/src/main/java/com/inscopemetrics/mad/telemetry/actors/ConnectionActor.java
+++ b/src/main/java/com/inscopemetrics/mad/telemetry/actors/ConnectionActor.java
@@ -147,27 +147,7 @@ public class ConnectionActor extends AbstractActor {
                             unhandled(message);
                         } else {
                             _metrics.recordCounter("actors/connection/UNKNOWN", 1);
-                            final String contentAsString;
-                            if (message instanceof TextMessage) {
-                                final TextMessage textMessage = (TextMessage) message;
-                                if (textMessage.isStrict()) {
-                                    contentAsString = textMessage.getStrictText();
-                                } else {
-                                    // TODO(ville): Latest Akka TextMessage has toStrict
-                                    // - Upgrade Play to upprade Akka
-                                    contentAsString = "<STREAMED>";
-                                }
-                                // TODO(ville): Support binary messages (when needed)
-                            } else {
-                                contentAsString = "<UNKNOWN>";
-                            }
-                            LOGGER.warn()
-                                    .setMessage("Unable to process message")
-                                    .addData("reason", "unsupported message")
-                                    .addData("actor", self())
-                                    .addData("data", contentAsString)
-                                    .log();
-                            unhandled(message);
+                            handleUnknownMessage(message);
                         }
                     }
                 })
@@ -343,6 +323,30 @@ public class ConnectionActor extends AbstractActor {
                 }
             }
         }
+    }
+
+    private void handleUnknownMessage(final Object message) {
+        final String contentAsString;
+        if (message instanceof TextMessage) {
+            final TextMessage textMessage = (TextMessage) message;
+            if (textMessage.isStrict()) {
+                contentAsString = textMessage.getStrictText();
+            } else {
+                // TODO(ville): Latest Akka TextMessage has toStrict
+                // - Upgrade Play to upprade Akka
+                contentAsString = "<STREAMED>";
+            }
+            // TODO(ville): Support binary messages (when needed)
+        } else {
+            contentAsString = "<UNKNOWN>";
+        }
+        LOGGER.warn()
+                .setMessage("Unable to process message")
+                .addData("reason", "unsupported message")
+                .addData("actor", self())
+                .addData("data", contentAsString)
+                .log();
+        unhandled(message);
     }
 
     private ActorRef _telemetry;


### PR DESCRIPTION
Minor fixes to problems encountered while testing CAGG Akka Persistence plugin upgrade. Notably, telemetry fixes to support configuration reloading and proper connection termination while telemetry actor is unavailable to reduce connection time from ~58 seconds to ~3 seconds.

Additional fixes include:
* ThreadLocalBuilder use for PeriodicData
* TelegrafJsonSource default port conflict
* Logging unrecognized telemetry protocol message payloads
* Telemetry connection and channel propagated shutdown