### PR TITLE
Remove Http Server Content Length Restriction

### DIFF
--- a/config/config.conf
+++ b/config/config.conf
@@ -28,9 +28,10 @@ akkaConfiguration {
     stdout-loglevel="DEBUG"
     logging-filter="akka.event.slf4j.Slf4jLoggingFilter"
     actor.debug.unhandled="on"
+    
+    # MAD is effectively a single client service and so a client sending large payments is
+    # only going to impact its own ability to accept and aggregate samples. However, if you
+    # have misbehaving clients or running a multi-tenant setup, you can rachet this down.
+    http.server.parsing.max-content-length="infinite"
   }
-  # MAD is effectively a single client service and so a client sending large payments is
-  # only going to impact its own ability to accept and aggregate samples. However, if you
-  # have misbehaving clients or running a multi-tenant setup, you can rachet this down.
-  http.server.parsing.max-content-length="infinite"
 }

--- a/config/config.conf
+++ b/config/config.conf
@@ -29,7 +29,7 @@ akkaConfiguration {
     logging-filter="akka.event.slf4j.Slf4jLoggingFilter"
     actor.debug.unhandled="on"
     
-    # MAD is effectively a single client service and so a client sending large payments is
+    # MAD is effectively a single client service and so a client sending large payloads is
     # only going to impact its own ability to accept and aggregate samples. However, if you
     # have misbehaving clients or running a multi-tenant setup, you can rachet this down.
     http.server.parsing.max-content-length="infinite"

--- a/config/config.conf
+++ b/config/config.conf
@@ -29,4 +29,8 @@ akkaConfiguration {
     logging-filter="akka.event.slf4j.Slf4jLoggingFilter"
     actor.debug.unhandled="on"
   }
+  # MAD is effectively a single client service and so a client sending large payments is
+  # only going to impact its own ability to accept and aggregate samples. However, if you
+  # have misbehaving clients or running a multi-tenant setup, you can rachet this down.
+  http.server.parsing.max-content-length="infinite"
 }


### PR DESCRIPTION
Lift restrictions on the Akka HTTP server content-length in the default config.