### PR TITLE
Fix TPStatistic hash

### DIFF
--- a/src/main/java/com/inscopemetrics/mad/statistics/TPStatistic.java
+++ b/src/main/java/com/inscopemetrics/mad/statistics/TPStatistic.java
@@ -65,6 +65,23 @@ public class TPStatistic extends BaseStatistic implements OrderedStatistic {
         return DEPENDENCIES.get();
     }
 
+    @Override
+    public int hashCode() {
+        return getName().hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TPStatistic)) {
+            return false;
+        }
+        final TPStatistic otherTPStatistic = (TPStatistic) o;
+        return getName().equals(otherTPStatistic.getName());
+    }
+
     /**
      * Protected constructor.
      *


### PR DESCRIPTION
Fix TPStatistic hashcode to use the name instead of the type as it is the only dynamic statistic.