### PR TITLE
Convert PeriodWorker to an Akka Actor.

### DIFF
--- a/src/main/java/com/arpnetworking/metrics/mad/Pipeline.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/Pipeline.java
@@ -66,6 +66,7 @@ public final class Pipeline implements Launchable {
         _sinks.add(rootSink);
 
         final Aggregator aggregator = new Aggregator.Builder()
+                .setActorSystem(_pipelineConfiguration.getActorSystem())
                 .setPeriods(_pipelineConfiguration.getPeriods())
                 .setTimerStatistics(_pipelineConfiguration.getTimerStatistics())
                 .setCounterStatistics(_pipelineConfiguration.getCounterStatistics())

--- a/src/main/java/com/arpnetworking/metrics/mad/configuration/PipelineConfiguration.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/configuration/PipelineConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.arpnetworking.metrics.mad.configuration;
 
+import akka.actor.ActorSystem;
 import com.arpnetworking.commons.builder.OvalBuilder;
 import com.arpnetworking.commons.jackson.databind.ObjectMapperFactory;
 import com.arpnetworking.logback.annotations.Loggable;
@@ -24,6 +25,7 @@ import com.arpnetworking.metrics.mad.model.statistics.Statistic;
 import com.arpnetworking.metrics.mad.model.statistics.StatisticDeserializer;
 import com.arpnetworking.metrics.mad.model.statistics.StatisticFactory;
 import com.arpnetworking.tsdcore.sinks.Sink;
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -80,6 +82,10 @@ public final class PipelineConfiguration {
         return objectMapper;
     }
 
+    public ActorSystem getActorSystem() {
+        return _actorSystem;
+    }
+
     public String getName() {
         return _name;
     }
@@ -116,6 +122,7 @@ public final class PipelineConfiguration {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("id", Integer.toHexString(System.identityHashCode(this)))
+                .add("ActorSystem", _actorSystem)
                 .add("Name", _name)
                 .add("Sources", _sources)
                 .add("Sinks", _sinks)
@@ -127,6 +134,7 @@ public final class PipelineConfiguration {
     }
 
     private PipelineConfiguration(final Builder builder) {
+        _actorSystem = builder._actorSystem;
         _name = builder._name;
         _sources = ImmutableList.copyOf(builder._sources);
         _sinks = ImmutableList.copyOf(builder._sinks);
@@ -137,6 +145,7 @@ public final class PipelineConfiguration {
         _statistics = ImmutableMap.copyOf(builder._statistics);
     }
 
+    private final ActorSystem _actorSystem;
     private final String _name;
     private final ImmutableList<Source> _sources;
     private final ImmutableList<Sink> _sinks;
@@ -160,6 +169,17 @@ public final class PipelineConfiguration {
          */
         public Builder() {
             super(PipelineConfiguration::new);
+        }
+
+        /**
+         * The Akka {@link ActorSystem}. Cannot be null.
+         *
+         * @param value The Akka {@link ActorSystem}.
+         * @return This instance of <code>Builder</code>.
+         */
+        public Builder setActorSystem(final ActorSystem value) {
+            _actorSystem = value;
+            return this;
         }
 
         /**
@@ -255,6 +275,9 @@ public final class PipelineConfiguration {
             return this;
         }
 
+        @NotNull
+        @JacksonInject
+        private ActorSystem _actorSystem;
         @NotNull
         @NotEmpty
         private String _name;

--- a/src/main/java/com/arpnetworking/metrics/mad/model/DefaultMetric.java
+++ b/src/main/java/com/arpnetworking/metrics/mad/model/DefaultMetric.java
@@ -160,6 +160,7 @@ public final class DefaultMetric implements Metric {
 
         @Override
         protected void reset() {
+            _statistics = ImmutableMap.of();
             _values = null;
             _type = null;
         }

--- a/src/main/java/com/arpnetworking/utility/AkkaForkJoinPoolAdapter.java
+++ b/src/main/java/com/arpnetworking/utility/AkkaForkJoinPoolAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.utility;
+
+/**
+ * This is a partial adapter to enable instrumentation of Akka's
+ * {@code ForkJoinPool} as if it were a Java {@code ForkJoinPool}.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ */
+public final class AkkaForkJoinPoolAdapter extends InstrumentingPoolAdapter {
+    /**
+     * Public constructor.
+     *
+     * @param akkaForkJoinPool pool to measure
+     */
+    public AkkaForkJoinPoolAdapter(final akka.dispatch.forkjoin.ForkJoinPool akkaForkJoinPool) {
+        _akkaForkJoinPool = akkaForkJoinPool;
+    }
+
+    private final akka.dispatch.forkjoin.ForkJoinPool _akkaForkJoinPool;
+
+    @Override
+    public int getParallelism() {
+        return _akkaForkJoinPool.getParallelism();
+    }
+
+    @Override
+    public int getPoolSize() {
+        return _akkaForkJoinPool.getPoolSize();
+    }
+
+    @Override
+    public int getRunningThreadCount() {
+        return _akkaForkJoinPool.getRunningThreadCount();
+    }
+
+    @Override
+    public int getActiveThreadCount() {
+        return _akkaForkJoinPool.getActiveThreadCount();
+    }
+
+    @Override
+    public boolean isQuiescent() {
+        return _akkaForkJoinPool.isQuiescent();
+    }
+
+    @Override
+    public long getStealCount() {
+        return _akkaForkJoinPool.getStealCount();
+    }
+
+    @Override
+    public long getQueuedTaskCount() {
+        return _akkaForkJoinPool.getQueuedTaskCount();
+    }
+
+    @Override
+    public int getQueuedSubmissionCount() {
+        return _akkaForkJoinPool.getQueuedSubmissionCount();
+    }
+
+    @Override
+    public boolean hasQueuedSubmissions() {
+        return _akkaForkJoinPool.hasQueuedSubmissions();
+    }
+
+    @Override
+    public String toString() {
+        return _akkaForkJoinPool.toString();
+    }
+}

--- a/src/main/java/com/arpnetworking/utility/InstrumentingPoolAdapter.java
+++ b/src/main/java/com/arpnetworking/utility/InstrumentingPoolAdapter.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2017 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.utility;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An adapter used to facilitate the instrumentation of work pools.  Allows for the use of
+ * functions that measure the state of the pool, but will throw an exception on any methods
+ * that submit work units or query work units.
+ *
+ * @author Brandon Arp (brandon dot arp at smartsheet dot com)
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public abstract class InstrumentingPoolAdapter extends java.util.concurrent.ForkJoinPool {
+    @Override
+    public <T> T invoke(final ForkJoinTask<T> task) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public void execute(final ForkJoinTask<?> task) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public void execute(final Runnable task) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> ForkJoinTask<T> submit(final ForkJoinTask<T> task) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> ForkJoinTask<T> submit(final Callable<T> task) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> T invokeAny(final Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> T invokeAny(
+            final Collection<? extends Callable<T>> tasks,
+            final long timeout,
+            final TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> ForkJoinTask<T> submit(final Runnable task, final T result) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public ForkJoinTask<?> submit(final Runnable task) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(
+            final Collection<? extends Callable<T>> tasks,
+            final long timeout,
+            final TimeUnit unit)
+            throws InterruptedException {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public ForkJoinWorkerThreadFactory getFactory() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public Thread.UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public boolean getAsyncMode() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public boolean isTerminated() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public boolean isTerminating() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public boolean isShutdown() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public boolean awaitTermination(final long timeout, final TimeUnit unit) throws InterruptedException {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public boolean awaitQuiescence(final long timeout, final TimeUnit unit) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    public abstract int getParallelism();
+
+    @Override
+    public abstract int getPoolSize();
+
+    @Override
+    public abstract int getRunningThreadCount();
+
+    @Override
+    public abstract int getActiveThreadCount();
+
+    @Override
+    public abstract boolean isQuiescent();
+
+    @Override
+    public abstract long getStealCount();
+
+    @Override
+    public abstract long getQueuedTaskCount();
+
+    @Override
+    public abstract int getQueuedSubmissionCount();
+
+    @Override
+    public abstract boolean hasQueuedSubmissions();
+
+    @Override
+    public abstract String toString();
+
+    @Override
+    protected ForkJoinTask<?> pollSubmission() {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    protected int drainTasksTo(final Collection<? super ForkJoinTask<?>> c) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(final Runnable runnable, final T value) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(final Callable<T> callable) {
+        throw new UnsupportedOperationException("This adapter only supports instrumentation");
+    }
+}

--- a/src/main/java/com/arpnetworking/utility/ScalaForkJoinPoolAdapter.java
+++ b/src/main/java/com/arpnetworking/utility/ScalaForkJoinPoolAdapter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 Smartsheet
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.arpnetworking.utility;
+
+import scala.concurrent.forkjoin.ForkJoinPool;
+
+/**
+ * This is a partial adapter to enable instrumentation of Scala's
+ * {@code ForkJoinPool} as if it were a Java {@code ForkJoinPool}.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot io)
+ */
+public final class ScalaForkJoinPoolAdapter extends InstrumentingPoolAdapter {
+
+    /**
+     * Public constructor.
+     *
+     * @param scalaForkJoinPool pool to measure
+     */
+    public ScalaForkJoinPoolAdapter(final ForkJoinPool scalaForkJoinPool) {
+        _scalaForkJoinPool = scalaForkJoinPool;
+    }
+
+    private final ForkJoinPool _scalaForkJoinPool;
+
+    @Override
+    public int getParallelism() {
+        return _scalaForkJoinPool.getParallelism();
+    }
+
+    @Override
+    public int getPoolSize() {
+        return _scalaForkJoinPool.getPoolSize();
+    }
+
+    @Override
+    public int getRunningThreadCount() {
+        return _scalaForkJoinPool.getRunningThreadCount();
+    }
+
+    @Override
+    public int getActiveThreadCount() {
+        return _scalaForkJoinPool.getActiveThreadCount();
+    }
+
+    @Override
+    public boolean isQuiescent() {
+        return _scalaForkJoinPool.isQuiescent();
+    }
+
+    @Override
+    public long getStealCount() {
+        return _scalaForkJoinPool.getStealCount();
+    }
+
+    @Override
+    public long getQueuedTaskCount() {
+        return _scalaForkJoinPool.getQueuedTaskCount();
+    }
+
+    @Override
+    public int getQueuedSubmissionCount() {
+        return _scalaForkJoinPool.getQueuedSubmissionCount();
+    }
+
+    @Override
+    public boolean hasQueuedSubmissions() {
+        return _scalaForkJoinPool.hasQueuedSubmissions();
+    }
+
+    @Override
+    public String toString() {
+        return _scalaForkJoinPool.toString();
+    }
+}


### PR DESCRIPTION
Changes:
* Send Record instances from Aggregator to Akka Actor
* Create an actor per key + period; actor covers all metrics with that key over time
* Kill all the actors on Aggregator shutdown
* Remove concurrent execution constructs in actor (PeriodWorker) and Bucket
* Add executor pool monitoring to Akka default dispatcher pool (from Metrics Portal)

Follow-up Work:
* Allow PeriodWorker actors to kill themselves and deregister from the Aggregator (key to actor map) after a period (>one period length + buffer) of no data. This was already a problem under the old scheme, so no degradation in that respect, just more work to be done.
* Convert any sinks with blocking code to Actors as well using the existing BaseActorSink. This will help avoid locking up Akka dispatcher pool threads and starving actors doing computation work. There may not be any (many sinks are already Vert.x or Akka). Also, this work may be more appropriately done in master-2.0.


Merging this is still subject to comparison testing we are running right now. We should have results in 12-18 hours.