### PR TITLE
Fix MAD Build; Kafka image creation broken

### DIFF
--- a/src/main/docker/kafka/Dockerfile
+++ b/src/main/docker/kafka/Dockerfile
@@ -18,8 +18,8 @@
 FROM java:openjdk-8-jre
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV SCALA_VERSION 2.11
-ENV KAFKA_VERSION 2.2.0
+ENV SCALA_VERSION 2.13
+ENV KAFKA_VERSION 2.5.0
 ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
 
 RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
@@ -30,9 +30,9 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update && \
     apt-get -o Acquire::Check-Valid-Until=false install -y zookeeper wget supervisor dnsutils && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean && \
-    wget -q http://apache.mirrors.spacedump.net/kafka/"$KAFKA_VERSION"/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -O /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz && \
-    tar xfz /tmp/kafka_2.11-"$KAFKA_VERSION".tgz -C /opt && \
-    rm /tmp/kafka_2.11-"$KAFKA_VERSION".tgz
+    wget -q "http://apache.mirrors.spacedump.net/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" && \
+    tar xfz "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" -C /opt && \
+    rm "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 
 ADD scripts/start-kafka.sh /usr/bin/start-kafka.sh
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -40,8 +40,11 @@
     </appender>
 
     <logger name="org.reflections.Reflections" level="ERROR" />
+    <logger name="io.inscopemetrics" level="DEBUG" />
+    <logger name="com.arpnetworking" level="DEBUG" />
+    <logger name="com.arpnetworking.metrics.apachehttpsinkextra.shaded" level="INFO" />
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="mad-async"/>
     </root>
 </configuration>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -25,8 +25,11 @@
     </appender>
 
     <logger name="org.reflections.Reflections" level="ERROR" />
+    <logger name="io.inscopemetrics" level="DEBUG" />
+    <logger name="com.arpnetworking" level="DEBUG" />
+    <logger name="com.arpnetworking.metrics.apachehttpsinkextra.shaded" level="INFO" />
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
* Upgrades Kafka from 2.2.0 to 2.5.0 and Scala with it from 2.11 to 2.13 (to fix build)
* Reduces logging output during build (because it was annoying and rather useless)