### PR TITLE
Normalize (and imo improve) periodic statistics collection in MAD.

### DIFF
--- a/src/main/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSink.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSink.java
@@ -390,9 +390,9 @@ public final class PeriodicStatisticsSink extends BaseSink {
         private final LongAccumulator _metricSamples = new LongAccumulator(Long::sum, 0);
         private final AtomicLong _aggregatedData = new AtomicLong(0);
         private final AtomicReference<Set<String>> _uniqueMetrics = new AtomicReference<>(
-                Collections.newSetFromMap(Maps.newConcurrentMap()));
+                ConcurrentHashMap.newKeySet());
         private final AtomicReference<Set<MetricKey>> _uniqueStatistics = new AtomicReference<>(
-                Collections.newSetFromMap(Maps.newConcurrentMap()));
+                ConcurrentHashMap.newKeySet());
     }
 
     /**

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSinkTest.java
@@ -31,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.hamcrest.MockitoHamcrest;
 
+import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.junit.Assert.assertEquals;
@@ -81,6 +82,29 @@ public class PeriodicStatisticsSinkTest {
     }
 
     @Test(expected = ConstraintsViolatedException.class)
+    public void testValidationDimensionCollisionWithPeriodDimensionName() {
+        new PeriodicStatisticsSink.Builder()
+                .setMetricsFactory(_mockMetricsFactory)
+                .setName("testValidationDimensionCollisionWithPeriodDimensionName")
+                .setDimensions(
+                        ImmutableSet.of(
+                                "_period"))
+                .build();
+    }
+
+    @Test(expected = ConstraintsViolatedException.class)
+    public void testValidationMappedDimensionCollisionWithPeriodDimensionName() {
+        new PeriodicStatisticsSink.Builder()
+                .setMetricsFactory(_mockMetricsFactory)
+                .setName("testValidationMappedDimensionCollisionWithPeriodDimensionName")
+                .setMappedDimensions(
+                        ImmutableMap.of(
+                                "foo", "abc",
+                                "bar", "_period"))
+                .build();
+    }
+
+    @Test(expected = ConstraintsViolatedException.class)
     public void testValidationDimensionCollisionAlthoughLogicallyEquivalent() {
         new PeriodicStatisticsSink.Builder()
                 .setMetricsFactory(_mockMetricsFactory)
@@ -127,38 +151,51 @@ public class PeriodicStatisticsSinkTest {
                         "bar", "def"));
 
         assertEquals(
-                new DefaultKey(ImmutableMap.of()),
+                new DefaultKey(ImmutableMap.of(
+                        "_period", "PT1M"
+                )),
                 PeriodicStatisticsSink.computeKey(
                         k,
+                        "_period",
+                        Duration.ofMinutes(1),
                         ImmutableMultimap.of()));
 
         assertEquals(
                 new DefaultKey(ImmutableMap.of(
+                        "_period", "PT1M",
                         "foo", "abc"
                 )),
                 PeriodicStatisticsSink.computeKey(
                         k,
+                        "_period",
+                        Duration.ofMinutes(1),
                         ImmutableMultimap.of(
                                 "foo", "foo"
                         )));
 
         assertEquals(
                 new DefaultKey(ImmutableMap.of(
+                        "_period", "PT1M",
                         "bar", "abc"
                 )),
                 PeriodicStatisticsSink.computeKey(
                         k,
+                        "_period",
+                        Duration.ofMinutes(1),
                         ImmutableMultimap.of(
                                 "foo", "bar"
                         )));
 
         assertEquals(
                 new DefaultKey(ImmutableMap.of(
+                        "_period", "PT1M",
                         "bar", "abc",
                         "foo", "def"
                 )),
                 PeriodicStatisticsSink.computeKey(
                         k,
+                        "_period",
+                        Duration.ofMinutes(1),
                         ImmutableMultimap.of(
                                 "foo", "bar",
                                 "bar", "foo"
@@ -167,14 +204,26 @@ public class PeriodicStatisticsSinkTest {
 
     @Test
     public void testFlushOnClose() {
-        final Sink statisticsSink = _statisticsSinkBuilder.build();
-        Mockito.verify(_mockMetricsFactory).create();
-        Mockito.verify(_mockMetrics).resetCounter(COUNTER_NAME);
+        final ScheduledExecutorService executor = Mockito.mock(ScheduledExecutorService.class);
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        final Sink statisticsSink = new PeriodicStatisticsSink(_statisticsSinkBuilder, executor);
+        Mockito.verify(executor).scheduleAtFixedRate(
+                runnableCaptor.capture(),
+                Mockito.anyLong(),
+                Mockito.anyLong(),
+                Mockito.any());
 
+        statisticsSink.recordAggregateData(TestBeanFactory.createPeriodicData());
         statisticsSink.close();
 
+        // The metrics are created when data is received and then replaced on
+        // flush (but the latter metrics instance is never closed or written to)
         Mockito.verify(_mockMetricsFactory, Mockito.times(2)).create();
         Mockito.verify(_mockMetrics, Mockito.times(2)).resetCounter(COUNTER_NAME);
+        Mockito.verify(_mockMetrics).incrementCounter(
+                Mockito.matches(COUNTER_NAME),
+                Mockito.anyLong());
+        Mockito.verify(_mockMetrics).close();
     }
 
     @Test
@@ -189,9 +238,6 @@ public class PeriodicStatisticsSinkTest {
                 Mockito.any());
 
         final Runnable periodicRunnable = runnableCaptor.getValue();
-
-        Mockito.verify(_mockMetricsFactory).create();
-        Mockito.verify(_mockMetrics).resetCounter(COUNTER_NAME);
 
         statisticsSink.recordAggregateData(TestBeanFactory.createPeriodicData());
         periodicRunnable.run();
@@ -221,9 +267,6 @@ public class PeriodicStatisticsSinkTest {
                 Mockito.anyLong(),
                 Mockito.any());
 
-        Mockito.verify(_mockMetricsFactory).create();
-        Mockito.verify(_mockMetrics).resetCounter(COUNTER_NAME);
-
         statisticsSink.recordAggregateData(TestBeanFactory.createPeriodicData());
         statisticsSink.close();
         Mockito.verify(_mockMetrics).incrementCounter(COUNTER_NAME, 1);
@@ -244,14 +287,9 @@ public class PeriodicStatisticsSinkTest {
                 Mockito.anyLong(),
                 Mockito.any());
 
-        Mockito.verify(_mockMetricsFactory).create();
-        Mockito.verify(_mockMetrics).resetCounter(COUNTER_NAME);
-
         final Metrics metricsA = Mockito.mock(Metrics.class);
         final Metrics metricsB = Mockito.mock(Metrics.class);
         final Metrics metricsUnused = Mockito.mock(Metrics.class);
-        Mockito.reset(_mockMetricsFactory);
-        Mockito.reset(_mockMetrics);
         Mockito.when(_mockMetricsFactory.create())
                 .thenReturn(metricsA, metricsB, metricsUnused);
 
@@ -265,7 +303,8 @@ public class PeriodicStatisticsSinkTest {
                 MockitoHamcrest.argThat(
                     Matchers.allOf(
                             Matchers.hasKey("host"),
-                            Matchers.aMapWithSize(1))));
+                            Matchers.hasKey("_period"),
+                            Matchers.aMapWithSize(2))));
         Mockito.verify(metricsA).close();
 
         // The second key also had a host annotation
@@ -274,11 +313,9 @@ public class PeriodicStatisticsSinkTest {
                 MockitoHamcrest.argThat(
                         Matchers.allOf(
                                 Matchers.hasKey("host"),
-                                Matchers.aMapWithSize(1))));
+                                Matchers.hasKey("_period"),
+                                Matchers.aMapWithSize(2))));
         Mockito.verify(metricsB).close();
-
-        // Global key had no metrics recorded against it, but it was closed
-        Mockito.verify(_mockMetrics).close();
 
         // The metrics instances that replaced A, B and Global on flush (via close) were never used
         Mockito.verify(metricsUnused, Mockito.never()).close();

--- a/src/test/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSinkTest.java
+++ b/src/test/java/com/arpnetworking/tsdcore/sinks/PeriodicStatisticsSinkTest.java
@@ -80,9 +80,24 @@ public class PeriodicStatisticsSinkTest {
                 .build();
     }
 
+    @Test(expected = ConstraintsViolatedException.class)
+    public void testValidationDimensionCollisionAlthoughLogicallyEquivalent() {
+        new PeriodicStatisticsSink.Builder()
+                .setMetricsFactory(_mockMetricsFactory)
+                .setName("testValidationDimensionCollisionAlthoughLogicallyEquivalent")
+                .setDimensions(
+                        ImmutableSet.of(
+                                "abc"))
+                .setMappedDimensions(
+                        ImmutableMap.of(
+                                "abc", "abc",
+                                "bar", "def"))
+                .build();
+    }
+
     @Test
     public void testValidationDimension() {
-        new PeriodicStatisticsSink.Builder()
+        final PeriodicStatisticsSink sink = new PeriodicStatisticsSink.Builder()
                 .setMetricsFactory(_mockMetricsFactory)
                 .setName("testValidationDimension")
                 .setDimensions(
@@ -94,6 +109,14 @@ public class PeriodicStatisticsSinkTest {
                                 "foo", "abc",
                                 "bar", "def"))
                 .build();
+        assertEquals(
+                ImmutableMultimap.<String, String>builder()
+                        .put("ghi", "ghi") // from dimensions
+                        .put("foo", "foo") // from dimensions
+                        .put("foo", "abc") // from mapped dimensions
+                        .put("bar", "def") // from mapped dimensions
+                        .build(),
+                sink.getMappedDimensions());
     }
 
     @Test


### PR DESCRIPTION
* Adds mappedDimension to PeriodicStatisticsSink to allow renaming of dimension extracted from the data stream and partitioning the output periodic statistics; (e.g. `_namespace` to `namespace`)
* Converts identifier `String` creation to use `Key` for metric+dimension-key (aka statistic tracking).
* Removes statistic from that tracking; MAD installs now only compute histogram internally.
* Removes period from that tracking; it doesn't really make sense (imo).
* Simplifies the `AggregatedData` iteration.
* Clarifies the usage of PeriodicStatistics sink; namely, that it should be used in a single period sink-chain.