### PR TITLE
Update metrics client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
     <log4j.over.slf4j.version>1.7.25</log4j.over.slf4j.version>
     <metrics.aggregator.protocol.prometheus.version>1.0.0</metrics.aggregator.protocol.prometheus.version>
     <metrics.aggregator.protocol.version>1.0.8</metrics.aggregator.protocol.version>
-    <metrics.client.version>0.11.0</metrics.client.version>
-    <metrics.client.http.version>0.11.0</metrics.client.http.version>
+    <metrics.client.version>0.11.1</metrics.client.version>
+    <metrics.client.http.version>0.11.1</metrics.client.http.version>
     <metrics.client.incubator.version>0.11.0</metrics.client.incubator.version>
     <metrics.jvm.extra.version>0.11.0</metrics.jvm.extra.version>
     <oval.version>1.90</oval.version>

--- a/src/test/java/com/arpnetworking/metrics/mad/integration/TelemetryIT.java
+++ b/src/test/java/com/arpnetworking/metrics/mad/integration/TelemetryIT.java
@@ -122,11 +122,11 @@ public final class TelemetryIT {
                                 .setMaximum(5.5)
                                 .setSum(60.5)
                                 .setHistogram(ImmutableMap.of(
-                                        1.1, 1,
-                                        2.2, 2,
-                                        3.3, 3,
-                                        4.4, 4,
-                                        5.5, 5))
+                                        1.1, 1L,
+                                        2.2, 2L,
+                                        3.3, 3L,
+                                        4.4, 4L,
+                                        5.5, 5L))
                                 .setPrecision(7)
                                 .build());
             }
@@ -139,11 +139,11 @@ public final class TelemetryIT {
                                 .setMaximum(11.0)
                                 .setSum(363.0)
                                 .setHistogram(ImmutableMap.of(
-                                        6.6, 6,
-                                        7.7, 7,
-                                        8.8, 8,
-                                        9.9, 9,
-                                        11.0, 10))
+                                        6.6, 6L,
+                                        7.7, 7L,
+                                        8.8, 8L,
+                                        9.9, 9L,
+                                        11.0, 10L))
                                 .setPrecision(7)
                                 .build());
             }
@@ -186,9 +186,9 @@ public final class TelemetryIT {
                                 .setMaximum(5.5)
                                 .setSum(55.0)
                                 .setHistogram(ImmutableMap.of(
-                                        3.3, 3,
-                                        4.4, 4,
-                                        5.5, 5))
+                                        3.3, 3L,
+                                        4.4, 4L,
+                                        5.5, 5L))
                                 .setPrecision(7)
                                 .build());
             }
@@ -209,8 +209,8 @@ public final class TelemetryIT {
                                 .setMaximum(11.0)
                                 .setSum(199.1)
                                 .setHistogram(ImmutableMap.of(
-                                        9.9, 9,
-                                        11.0, 10))
+                                        9.9, 9L,
+                                        11.0, 10L))
                                 .setPrecision(7)
                                 .build());
             }


### PR DESCRIPTION
Adopt latest metrics-client-java and metrics-apache-http-sink to send user dimensions; specifically, to support new partitioning of data in PeriodicStatisticsSink via dimensions.

The updated client also includes 64-bit bucket count support, hence the changes to `TelemetryIT.java` which sends data through MAD to test Telemetry. Support within MAD for 64-bit bucket counts was added in #181.