### PR TITLE
Use time construct for RequestEntry enterTime 

### DIFF
--- a/src/main/java/com/arpnetworking/tsdcore/model/RequestEntry.java
+++ b/src/main/java/com/arpnetworking/tsdcore/model/RequestEntry.java
@@ -19,6 +19,8 @@ import com.arpnetworking.commons.builder.OvalBuilder;
 import net.sf.oval.constraint.NotNull;
 import org.asynchttpclient.Request;
 
+import java.time.Instant;
+
 /**
  * Contains the info for a http request.
  *
@@ -29,7 +31,7 @@ public final class RequestEntry {
         return _request;
     }
 
-    public long getEnterTime() {
+    public Instant getEnterTime() {
         return _enterTime;
     }
 
@@ -44,7 +46,7 @@ public final class RequestEntry {
     }
 
     private final Request _request;
-    private long _enterTime;
+    private Instant _enterTime;
     private final long _populationSize;
 
     /**
@@ -80,7 +82,7 @@ public final class RequestEntry {
          * @param value The enter time.
          * @return This {@link Builder} instance.
          */
-        public Builder setEnterTime(final long value) {
+        public Builder setEnterTime(final Instant value) {
             _enterTime = value;
             return this;
         }
@@ -99,7 +101,7 @@ public final class RequestEntry {
         @NotNull
         private Request _request;
         @NotNull
-        private Long _enterTime;
+        private Instant _enterTime;
         @NotNull
         private Long _populationSize;
     }

--- a/src/main/java/com/arpnetworking/tsdcore/sinks/HttpPostSinkActor.java
+++ b/src/main/java/com/arpnetworking/tsdcore/sinks/HttpPostSinkActor.java
@@ -39,6 +39,7 @@ import org.asynchttpclient.Response;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -218,7 +219,7 @@ public class HttpPostSinkActor extends AbstractActor {
             for (final RequestEntry.Builder requestEntryBuilder : requestEntryBuilders) {
                 // TODO(vkoskela): Add logging to client [MAI-89]
                 // TODO(vkoskela): Add instrumentation to client [MAI-90]
-                _pendingRequests.offer(requestEntryBuilder.setEnterTime(System.currentTimeMillis()).build());
+                _pendingRequests.offer(requestEntryBuilder.setEnterTime(Instant.now()).build());
             }
 
             if (evicted > 0) {
@@ -271,7 +272,8 @@ public class HttpPostSinkActor extends AbstractActor {
     private void fireNextRequest() {
         final RequestEntry requestEntry = _pendingRequests.poll();
         final Metrics metrics = _metricsFactory.create();
-        metrics.setTimer(_inQueueLatencyName, System.currentTimeMillis() - requestEntry.getEnterTime(), TimeUnit.MILLISECONDS);
+        final long latencyInMillis = Duration.between(requestEntry.getEnterTime(), Instant.now()).toMillis();
+        metrics.setTimer(_inQueueLatencyName, latencyInMillis, TimeUnit.MILLISECONDS);
 
         final Request request = requestEntry.getRequest();
         _inflightRequestsCount++;


### PR DESCRIPTION
In the RequestEntry and HttpSink queue latency, change usage to time.Instant for type and time.Duration for arithmetic on timestamps instead of long for semantic clarity